### PR TITLE
Fix logos and videos path in layer1

### DIFF
--- a/frontend/a/points/p1/layer1.html
+++ b/frontend/a/points/p1/layer1.html
@@ -149,7 +149,7 @@
   <header>
 
     <div class="header-left">
-      <img src="../../images/maarifLOGO.png" class="logo" />
+      <img src="../../../images/maarifLOGO.png" class="logo" />
     </div>
     <div class="header-center">
       <h1>LAYER 1: Theory Notes of <span id="point-title">P1</span></h1>
@@ -157,7 +157,7 @@
       <p id="platform-name"></p>
     </div>
     <div class="header-right" style="text-align:right;">
-      <img src="../../images/Cambridgelogo.png" class="logo" />
+      <img src="../../../images/cambridge.png" class="logo" />
 
     </div>
   </header>
@@ -172,7 +172,7 @@
       <img src="syllabus.png" alt="Syllabus Image" style="max-width: 100%; margin-bottom: 20px;" />
 
       <div class="section-title">📄 Official Theory Notes</div>
-      <iframe src="https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true" height="900"></iframe>
+      <iframe src="https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true" height="2000" scrolling="no"></iframe>
     </div>
 
     <div class="notes-container">
@@ -219,7 +219,7 @@
     document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
     document.getElementById("content-area").style.display = "flex";
 
-    fetch("../../videos.json")
+    fetch("videos.json")
       .then(res => res.json())
       .then(videos => {
         if (videos[point_id] && videos[point_id].length > 0) {


### PR DESCRIPTION
## Summary
- fix broken logo links
- load videos.json from the correct location
- increase theory notes iframe height to avoid scrolling

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865743ed86883318ed69347c0797874