### PR TITLE
Dynamic progress bar in dashboard

### DIFF
--- a/frontend/a/dashboard.css
+++ b/frontend/a/dashboard.css
@@ -408,7 +408,7 @@ body {
 .general-progress-fill {
   height: 100%;
   background-color: #4CAF50;
-  width: 62%; /* Static for now */
+  width: 0%;
   border-radius: 10px 0 0 10px;
 }
 /* Remove ↓ arrows and add nice connecting line */
@@ -447,7 +447,7 @@ body {
 .general-progress-fill {
   height: 100%;
   background-color: #4CAF50;
-  width: 62%;
+  width: 0%;
   border-radius: 10px 0 0 10px;
   text-align: center;
   color: white;
@@ -490,7 +490,7 @@ footer {
 }
 .general-progress-fill {
   height: 100%;
-  width: 62%; /* static for now */
+  width: 0%;
   background-color: #4CAF50;
   text-align: center;
   color: white;
@@ -536,7 +536,7 @@ footer {
 
 .general-progress-fill {
   height: 100%;
-  width: 62%; /* static for now */
+  width: 0%;
   background-color: #4CAF50;
   text-align: center;
   color: white;

--- a/frontend/a/dashboard.html
+++ b/frontend/a/dashboard.html
@@ -22,10 +22,10 @@
     </div>
     <div class="general-progress-wrapper">
       <div class="general-progress-label">GENERAL PROGRESS</div>
-      <div class="general-progress-bar">
-        <div class="general-progress-fill">62%</div>
-        <div class="general-progress-max">100%</div>
-      </div>
+        <div class="general-progress-bar">
+          <div class="general-progress-fill">0%</div>
+          <div class="general-progress-max">100%</div>
+        </div>
     </div>
   </div>
 

--- a/frontend/a/dashboard.js
+++ b/frontend/a/dashboard.js
@@ -1,7 +1,34 @@
 
 import { renderTheoryPoints } from "./modules/theoryRenderer.js";
 import { renderProgrammingLevels } from "./modules/levelRenderer.js";
-import { initializeLogin } from "./modules/supabase.js";
+import { initializeLogin, fetchProgressCounts } from "./modules/supabase.js";
+
+async function updateGeneralProgress() {
+  const fill = document.querySelector(".general-progress-fill");
+  if (!fill) return;
+
+  let totalPoints = 0;
+  try {
+    const res = await fetch("./points/index.json");
+    if (res.ok) {
+      const pts = await res.json();
+      totalPoints = pts.length;
+    }
+  } catch (err) {
+    console.error("Failed to load points index:", err);
+  }
+
+  const totalLevels = 16; // defined in levelRenderer
+
+  const { points, levels } = await fetchProgressCounts();
+
+  const total = totalPoints + totalLevels;
+  const done = points + levels;
+  const percent = total ? Math.round((done / total) * 100) : 0;
+
+  fill.style.width = percent + "%";
+  fill.textContent = percent + "%";
+}
 
 document.addEventListener("DOMContentLoaded", () => {
   console.log("✅ DOM fully loaded, running dashboard.js");
@@ -9,6 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderTheoryPoints();
   renderProgrammingLevels();
   initializeLogin();
+  updateGeneralProgress();
 
   const homeBtn = document.getElementById("home-btn");
   if (homeBtn) {

--- a/frontend/a/modules/supabase.js
+++ b/frontend/a/modules/supabase.js
@@ -1,4 +1,64 @@
 
+const SUPABASE_URL = "https://tsmzmuclrnyryuvanlxl.supabase.co";
+const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
+
+function tableName(platform, type) {
+  const map = {
+    A_Level: {
+      theory: 'a_theory_progress',
+      programming: 'a_programming_progress'
+    },
+    AS_Level: {
+      theory: 'as_theory_progress',
+      programming: 'as_programming_progress'
+    },
+    IGCSE: {
+      theory: 'igcse_theory_progress',
+      programming: 'igcse_programming_progress'
+    }
+  };
+  return map[platform] ? map[platform][type] : null;
+}
+
+export async function fetchProgressCounts() {
+  const studentId = localStorage.getItem('student_id');
+  const platform = localStorage.getItem('platform');
+
+  if (!studentId || !platform) return { points: 0, levels: 0 };
+
+  const theoryTable = tableName(platform, 'theory');
+  const levelTable = tableName(platform, 'programming');
+  const base = `${SUPABASE_URL}/rest/v1`;
+
+  try {
+    const [tRes, lRes] = await Promise.all([
+      fetch(`${base}/${theoryTable}?select=layer4_done&studentid=eq.${studentId}`, {
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: 'Bearer ' + SUPABASE_KEY
+        }
+      }),
+      fetch(`${base}/${levelTable}?select=level_done&studentid=eq.${studentId}`, {
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: 'Bearer ' + SUPABASE_KEY
+        }
+      })
+    ]);
+
+    const tData = await tRes.json();
+    const lData = await lRes.json();
+
+    const passedPoints = tData.filter(r => r.layer4_done).length;
+    const passedLevels = lData.filter(r => r.level_done).length;
+
+    return { points: passedPoints, levels: passedLevels };
+  } catch (err) {
+    console.error('❌ Failed fetching progress counts:', err);
+    return { points: 0, levels: 0 };
+  }
+}
+
 export function initializeLogin() {
   const loginBtn = document.getElementById("login-btn");
   const logoutBtn = document.getElementById("logout-btn");
@@ -14,8 +74,7 @@ export function initializeLogin() {
       const username = document.getElementById("username").value;
       const password = document.getElementById("password").value;
 
-      const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
-      const url = "https://tsmzmuclrnyryuvanlxl.supabase.co/rest/v1/students?select=*&username=eq." + encodeURIComponent(username) + "&password=eq." + encodeURIComponent(password);
+      const url = `${SUPABASE_URL}/rest/v1/students?select=*&username=eq.${encodeURIComponent(username)}&password=eq.${encodeURIComponent(password)}`;
 
       console.log("🔍 Sending login request to Supabase:", url);
 


### PR DESCRIPTION
## Summary
- make general progress bar dynamic by fetching completed points and levels from Supabase
- expose a helper in `supabase.js` to read progress counts
- compute progress on page load in `dashboard.js`
- default progress bar width is now 0%

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5352264833192f6d2d0807f7303