### PR TITLE
Dynamic progress bar in dashboard

### DIFF
--- a/frontend/a/dashboard.css
+++ b/frontend/a/dashboard.css
@@ -408,7 +408,7 @@ body {
 .general-progress-fill {
   height: 100%;
   background-color: #4CAF50;
-  width: 62%; /* Static for now */
+  width: 0%;
   border-radius: 10px 0 0 10px;
 }
 /* Remove ↓ arrows and add nice connecting line */
@@ -447,7 +447,7 @@ body {
 .general-progress-fill {
   height: 100%;
   background-color: #4CAF50;
-  width: 62%;
+  width: 0%;
   border-radius: 10px 0 0 10px;
   text-align: center;
   color: white;
@@ -490,7 +490,7 @@ footer {
 }
 .general-progress-fill {
   height: 100%;
-  width: 62%; /* static for now */
+  width: 0%;
   background-color: #4CAF50;
   text-align: center;
   color: white;
@@ -536,7 +536,7 @@ footer {
 
 .general-progress-fill {
   height: 100%;
-  width: 62%; /* static for now */
+  width: 0%;
   background-color: #4CAF50;
   text-align: center;
   color: white;

--- a/frontend/a/dashboard.html
+++ b/frontend/a/dashboard.html
@@ -22,10 +22,10 @@
     </div>
     <div class="general-progress-wrapper">
       <div class="general-progress-label">GENERAL PROGRESS</div>
-      <div class="general-progress-bar">
-        <div class="general-progress-fill">62%</div>
-        <div class="general-progress-max">100%</div>
-      </div>
+        <div class="general-progress-bar">
+          <div class="general-progress-fill">0%</div>
+          <div class="general-progress-max">100%</div>
+        </div>
     </div>
   </div>
 

--- a/frontend/a/dashboard.js
+++ b/frontend/a/dashboard.js
@@ -1,14 +1,42 @@
 
 import { renderTheoryPoints } from "./modules/theoryRenderer.js";
 import { renderProgrammingLevels } from "./modules/levelRenderer.js";
-import { initializeLogin } from "./modules/supabase.js";
+import { initializeLogin, fetchProgressCounts } from "./modules/supabase.js";
 
-document.addEventListener("DOMContentLoaded", () => {
+async function updateGeneralProgress() {
+  const fill = document.querySelector(".general-progress-fill");
+  if (!fill) return;
+
+  let totalPoints = 0;
+  try {
+    const res = await fetch("./points/index.json");
+    if (res.ok) {
+      const pts = await res.json();
+      totalPoints = pts.length;
+    }
+  } catch (err) {
+    console.error("Failed to load points index:", err);
+  }
+
+  const totalLevels = 16; // defined in levelRenderer
+
+  const { points, levels } = await fetchProgressCounts();
+
+  const total = totalPoints + totalLevels;
+  const done = points + levels;
+  const percent = total ? Math.round((done / total) * 100) : 0;
+
+  fill.style.width = percent + "%";
+  fill.textContent = percent + "%";
+}
+
+document.addEventListener("DOMContentLoaded", async () => {
   console.log("✅ DOM fully loaded, running dashboard.js");
 
   renderTheoryPoints();
-  renderProgrammingLevels();
+  await renderProgrammingLevels();
   initializeLogin();
+  updateGeneralProgress();
 
   const homeBtn = document.getElementById("home-btn");
   if (homeBtn) {

--- a/frontend/a/modules/levelRenderer.js
+++ b/frontend/a/modules/levelRenderer.js
@@ -1,5 +1,7 @@
 
-export function renderProgrammingLevels() {
+import { fetchPassedLevels } from "./supabase.js";
+
+export async function renderProgrammingLevels() {
   const container = document.getElementById("programming-levels");
   if (!container) return;
 
@@ -22,16 +24,26 @@ export function renderProgrammingLevels() {
     { title: "Final Project", id: "level16", status: "locked" }
   ];
 
+  const passed = await fetchPassedLevels();
+  const highestPassed = passed.length ? Math.max(...passed) : 0;
+
   levels.forEach((level, index) => {
+    const num = index + 1;
+    let status = "locked";
+    if (passed.includes(num)) {
+      status = "passed";
+    } else if (num === highestPassed + 1) {
+      status = "unlocked";
+    }
+
     const box = document.createElement("div");
-    box.className = `level-box ${level.status}`;
+    box.className = `level-box ${status}`;
     box.innerHTML = `
-      <strong>Level ${index + 1}</strong><br/>
+      <strong>Level ${num}</strong><br/>
       <span>${level.title}</span>
     `;
     container.appendChild(box);
 
-    // Insert red arrow image between levels except after last one
     if (index < levels.length - 1) {
       const arrow = document.createElement("img");
       arrow.src = "images/arrow.png";


### PR DESCRIPTION
## Summary
- make general progress bar dynamic by fetching completed points and levels from Supabase
- expose a helper in `supabase.js` to read progress counts
- compute progress on page load in `dashboard.js`
- default progress bar width is now 0%
- unlock levels based on passed level data from Supabase

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865c5352264833192f6d2d0807f7303