### PR TITLE
Improve level visuals

### DIFF
--- a/frontend/a/dashboard.css
+++ b/frontend/a/dashboard.css
@@ -342,12 +342,16 @@ body {
   background-color: #e0e0e0;
   border-radius: 10px;
   padding: 12px;
-  margin: 20px auto;
-  width: 80%;
+  margin: 10px auto;
+  width: 64%;
   transition: transform 0.2s ease;
   cursor: pointer;
-  text-align: center;
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  text-align: left;
 }
 .level-box:hover {
   transform: scale(1.02);
@@ -361,6 +365,12 @@ body {
 .level-box.passed {
   background-color: #4CAF50;
   color: white;
+}
+.level-icon {
+  font-size: 1.2em;
+}
+.level-text {
+  line-height: 1.2;
 }
 /* Arrows between levels */
 .level-box:not(:last-child)::after {
@@ -429,7 +439,7 @@ body {
 /* Insert PNG-based arrow between levels */
 .arrow-img {
   width: 20px;
-  margin: 0 auto 15px;
+  margin: 0 auto 5px;
   display: block;
 }
 .general-progress-label {

--- a/frontend/a/modules/levelRenderer.js
+++ b/frontend/a/modules/levelRenderer.js
@@ -25,9 +25,18 @@ export function renderProgrammingLevels() {
   levels.forEach((level, index) => {
     const box = document.createElement("div");
     box.className = `level-box ${level.status}`;
+
+    let icon = "";
+    if (level.status === "locked") icon = "\uD83D\uDD12"; // 🔒
+    else if (level.status === "unlocked") icon = "\uD83D\uDD13"; // 🔓
+    else if (level.status === "passed") icon = "\u2705"; // ✅
+
     box.innerHTML = `
-      <strong>Level ${index + 1}</strong><br/>
-      <span>${level.title}</span>
+      <span class="level-icon">${icon}</span>
+      <div class="level-text">
+        <strong>Level ${index + 1}</strong><br/>
+        <span>${level.title}</span>
+      </div>
     `;
     container.appendChild(box);
 


### PR DESCRIPTION
## Summary
- add lock/unlock emojis to each level
- reduce width of level boxes
- tighten spacing between levels and arrows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865c960d7688331bbb407f28b3da02e