### PR TITLE
Improve teacher dashboard layout

### DIFF
--- a/frontend/teacher/teacher-dashboard.html
+++ b/frontend/teacher/teacher-dashboard.html
@@ -29,8 +29,10 @@
 
     <main class="student-progress">
       <h3 id="student-title">Select a student to view progress</h3>
-      <div id="theory-progress"></div>
-      <div id="programming-progress"></div>
+      <div class="progress-columns">
+        <div id="theory-progress"></div>
+        <div id="programming-progress"></div>
+      </div>
       <button id="save-progress" class="save-btn" style="display: none;">Save Progress</button>
       <div id="save-msg"></div>
     </main>

--- a/frontend/teacher/teacher.css
+++ b/frontend/teacher/teacher.css
@@ -48,6 +48,7 @@ header {
   flex-grow: 1;
   padding: 20px;
 }
+
 #student-title {
   font-weight: bold;
   font-size: 1.2em;
@@ -57,4 +58,30 @@ header {
   font-size: 0.95em;
   margin-top: 8px;
   color: green;
+}
+
+/* Layout for progress columns */
+.progress-columns {
+  display: flex;
+  gap: 20px;
+  align-items: flex-start;
+}
+
+#theory-progress,
+#programming-progress {
+  flex: 1;
+}
+
+/* Style individual rows inside progress tables */
+.point-row,
+.level-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.point-label,
+.level-label {
+  width: 140px;
 }


### PR DESCRIPTION
## Summary
- display theory and programming sections side-by-side on the teacher dashboard
- style progress columns and rows for easier reading

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6866e0c09e34833192ce4ae2533c3a57