### PR TITLE
Improve official notes layout

### DIFF
--- a/frontend/a/points/p1/layer1.html
+++ b/frontend/a/points/p1/layer1.html
@@ -6,6 +6,9 @@
   <link rel="stylesheet" href="../../dashboard.css" />
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
     body {
       font-family: 'Segoe UI', sans-serif;
       margin: 0;
@@ -53,17 +56,18 @@
     }
 
     .doc-container {
-      flex: 0 0 850px;
-      max-width: 100%;
-      display: flex;
-      flex-direction: column;
-    }
-
-    .notes-container {
-      flex: 1;
+      flex: 3;
       display: flex;
       flex-direction: column;
       padding-right: 20px;
+      border-right: 2px solid #ccc;
+    }
+
+    .notes-container {
+      flex: 2;
+      display: flex;
+      flex-direction: column;
+      padding-left: 20px;
     }
 
     .notes-container label {
@@ -73,7 +77,8 @@
 
     .notes-container textarea {
       width: 100%;
-      height: 400px;
+      height: 100%;
+      flex: 1;
       padding: 15px;
       font-size: 1em;
       border-radius: 6px;
@@ -84,8 +89,17 @@
     .section-title {
       font-weight: bold;
       margin: 15px 0 8px;
-      font-size: 1.1em;
-      color: #003366;
+      font-size: 1.2em;
+      color: #fff;
+      background: #003366;
+      padding: 6px 10px;
+      border-radius: 4px;
+    }
+
+    #video-section {
+      margin-bottom: 20px;
+      padding-bottom: 20px;
+      border-bottom: 1px solid #ccc;
     }
 
     iframe {
@@ -93,6 +107,16 @@
       border: 1px solid #ccc;
       border-radius: 6px;
       margin-bottom: 20px;
+    }
+
+    #official-notes {
+      overflow-x: hidden;
+    }
+
+    .official-doc {
+      width: calc(100% / 1.1);
+      transform: scale(1.1);
+      transform-origin: top left;
     }
 
     .actions {
@@ -198,7 +222,9 @@
       <img src="syllabus.png" alt="Syllabus Image" style="max-width: 100%; margin-bottom: 20px;" />
 
       <div class="section-title">📄 Official Theory Notes</div>
-      <iframe src="https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true" height="2000" scrolling="no"></iframe>
+      <div id="official-notes">
+        <iframe class="official-doc" src="https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true" height="2000" scrolling="no"></iframe>
+      </div>
     </div>
 
     <div class="notes-container">


### PR DESCRIPTION
## Summary
- prevent layout overflow by using `box-sizing` and flex ratios
- scale up official notes iframe to fill its section

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6866ddc5bd0c8331a1adb7afa91458b9