### PR TITLE
Improve teacher login security

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -17,6 +17,7 @@ HAMDENI COMPUTER SCIENCE PLATFORM – DEPLOYMENT GUIDE
 4. Set these values:
    - Build Command: (leave blank)
    - Publish Directory: public
+   - Environment Variable TEACHER_PASSWORD_HASH: set to the SHA-256 hash of your desired teacher password
 
 📌 STEP 2 – Add Custom Domain (hamdeni-cs.tn)
 ---------------------------------------------

--- a/frontend/teacher/teacher.js
+++ b/frontend/teacher/teacher.js
@@ -5,15 +5,34 @@ const SUPABASE_URL = "https://tsmzmuclrnyryuvanlxl.supabase.co";
 const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
-if (!localStorage.getItem("teacher-auth")) {
-  const pass = prompt("Enter teacher password:");
-  if (pass !== "maarifadmin") {
-    alert("Access denied.");
-    window.location.href = "/index.html";
+async function ensureAuth() {
+  if (localStorage.getItem('teacher-token')) {
+    return;
+  }
+
+  const pass = prompt('Enter teacher password:');
+  if (!pass) {
+    alert('Access denied.');
+    window.location.href = '/index.html';
+    return;
+  }
+
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ password: pass })
+  });
+
+  if (res.ok) {
+    const data = await res.json();
+    localStorage.setItem('teacher-token', data.token);
   } else {
-    localStorage.setItem("teacher-auth", "1");
+    alert('Access denied.');
+    window.location.href = '/index.html';
   }
 }
+
+await ensureAuth();
 
 let selectedStudent = null;
 let selectedPlatform = null;

--- a/server/index.js
+++ b/server/index.js
@@ -1,8 +1,28 @@
 const express = require('express');
 const path = require('path');
+const crypto = require('crypto');
+
 const app = express();
 const PORT = process.env.PORT || 3000;
+
+app.use(express.json());
 app.use(express.static(path.join(__dirname, '..', 'frontend')));
+
+app.post('/api/login', (req, res) => {
+  const password = req.body.password || '';
+  const hash = crypto.createHash('sha256').update(password).digest('hex');
+  const storedHash = process.env.TEACHER_PASSWORD_HASH || '';
+
+  if (
+    storedHash.length === hash.length &&
+    crypto.timingSafeEqual(Buffer.from(hash), Buffer.from(storedHash))
+  ) {
+    const token = crypto.randomBytes(20).toString('hex');
+    res.json({ token });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+});
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '..', 'frontend', req.url));
 });


### PR DESCRIPTION
## Summary
- remove plaintext password from frontend logic
- add secure `/api/login` endpoint that compares hashed password
- save login token to localStorage instead of storing password
- mention `TEACHER_PASSWORD_HASH` env var in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866e523eab88331a000efabcf726a7c