### PR TITLE
Fix wildcard route traversal

### DIFF
--- a/manual-test.sh
+++ b/manual-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Manual verification script for path traversal check
+# Starts the server and requests /../../package.json
+# Requires express dependencies installed.
+
+set -e
+PORT=3000
+
+node server/index.js >/tmp/test_server.log 2>&1 &
+PID=$!
+# give server time to start
+sleep 1
+
+status_code=$(curl -o /tmp/resp -w "%{http_code}" -s http://localhost:$PORT/../../package.json || true)
+kill $PID
+wait $PID 2>/dev/null || true
+
+cat /tmp/test_server.log
+cat /tmp/resp
+
+echo "Status: $status_code"

--- a/server/index.js
+++ b/server/index.js
@@ -14,8 +14,22 @@ app.get('/config.js', (req, res) => {
   res.send(`window.APP_CONFIG = ${JSON.stringify(config)};`);
 });
 app.use(express.static(path.join(__dirname, '..', 'frontend')));
+
+// Fallback route with path normalization to prevent directory traversal
 app.get('*', (req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'frontend', req.url));
+  const frontendRoot = path.join(__dirname, '..', 'frontend');
+  const normalized = path.normalize(req.path).replace(/^\/+/, '');
+  const absolutePath = path.join(frontendRoot, normalized);
+
+  if (!absolutePath.startsWith(frontendRoot)) {
+    return res.status(404).sendFile(path.join(__dirname, '..', '404.html'));
+  }
+
+  res.sendFile(absolutePath, err => {
+    if (err) {
+      res.status(err.statusCode === 404 ? 404 : 500).sendFile(path.join(__dirname, '..', '404.html'));
+    }
+  });
 });
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
## Summary
- prevent directory traversal in fallback route by normalizing `req.path`
- add a script for manually verifying `/../../package.json` returns 404

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686877cd0d6483318a669572044c0c19