### PR TITLE
Add level pages and update headers

### DIFF
--- a/frontend/a/levels/level1.html
+++ b/frontend/a/levels/level1.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 1</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 1</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 1 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level10.html
+++ b/frontend/a/levels/level10.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 10</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 10</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 10 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level11.html
+++ b/frontend/a/levels/level11.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 11</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 11</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 11 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level12.html
+++ b/frontend/a/levels/level12.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 12</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 12</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 12 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level13.html
+++ b/frontend/a/levels/level13.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 13</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 13</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 13 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level14.html
+++ b/frontend/a/levels/level14.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 14</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 14</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 14 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level15.html
+++ b/frontend/a/levels/level15.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 15</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 15</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 15 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level16.html
+++ b/frontend/a/levels/level16.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 16</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 16</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 16 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level2.html
+++ b/frontend/a/levels/level2.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 2</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 2</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 2 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level3.html
+++ b/frontend/a/levels/level3.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 3</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 3</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 3 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level4.html
+++ b/frontend/a/levels/level4.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 4</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 4</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 4 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level5.html
+++ b/frontend/a/levels/level5.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 5</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 5</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 5 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level6.html
+++ b/frontend/a/levels/level6.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 6</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 6</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 6 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level7.html
+++ b/frontend/a/levels/level7.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 7</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 7</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 7 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level8.html
+++ b/frontend/a/levels/level8.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 8</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 8</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 8 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/levels/level9.html
+++ b/frontend/a/levels/level9.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Level 9</title>
+  <link rel="stylesheet" href="../dashboard.css" />
+</head>
+<body>
+  <header style="text-align:center;padding:20px;background:#003366;color:#fff;">
+    <h1>Programming Level 9</h1>
+  </header>
+  <main style="padding:20px;text-align:center;">
+    <p>Content for Level 9 goes here.</p>
+  </main>
+</body>
+</html>

--- a/frontend/a/modules/levelRenderer.js
+++ b/frontend/a/modules/levelRenderer.js
@@ -25,6 +25,7 @@ export function renderProgrammingLevels() {
   levels.forEach((level, index) => {
     const box = document.createElement("div");
     box.className = `level-box ${level.status}`;
+    box.dataset.level = index + 1;
 
     let icon = "";
     if (level.status === "locked") icon = "\uD83D\uDD12"; // 🔒
@@ -38,6 +39,14 @@ export function renderProgrammingLevels() {
         <span>${level.title}</span>
       </div>
     `;
+    box.addEventListener("click", () => {
+      if (box.classList.contains("locked")) {
+        alert("This level is locked.");
+      } else {
+        window.location.href = `./levels/level${index + 1}.html`;
+      }
+    });
+
     container.appendChild(box);
 
     // Insert red arrow image between levels except after last one

--- a/frontend/a/points/p1/layer1.html
+++ b/frontend/a/points/p1/layer1.html
@@ -204,7 +204,7 @@
       </a>
     </div>
     <div class="header-center">
-      <h1>LAYER 1: Theory Notes of <span id="point-title">P1</span></h1>
+      <h1>Theoretical Foundation</h1>
       <p id="student-name"></p>
       <p id="platform-name"></p>
     </div>

--- a/frontend/a/points/p1/layer2.html
+++ b/frontend/a/points/p1/layer2.html
@@ -178,7 +178,7 @@
       </a>
     </div>
     <div class="header-center">
-      <h1>LAYER 2: Basic Understanding of <span id="point-title">P1</span></h1>
+      <h1>Active Application</h1>
       <p id="student-name"></p>
       <p id="platform-name"></p>
     </div>


### PR DESCRIPTION
## Summary
- update Layer 1 header to "Theoretical Foundation"
- update Layer 2 header to "Active Application"
- add a new `levels` directory with placeholder pages for levels 1‒16
- allow clicking a level in the dashboard only if it is unlocked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868f598cf648331a14c554bfabfb21e