### PR TITLE
Switch config to static file

### DIFF
--- a/frontend/config.js
+++ b/frontend/config.js
@@ -1,0 +1,5 @@
+window.APP_CONFIG = {
+  SUPABASE_URL: 'https://your-project.supabase.co',
+  SUPABASE_KEY: 'your-public-anon-key',
+  TEACHER_PASSWORD: 'your-password'
+};

--- a/server/index.js
+++ b/server/index.js
@@ -9,10 +9,12 @@ const config = {
   TEACHER_PASSWORD: process.env.TEACHER_PASSWORD || ''
 };
 
-app.get('/config.js', (req, res) => {
-  res.type('application/javascript');
-  res.send(`window.APP_CONFIG = ${JSON.stringify(config)};`);
-});
+// Static config.js is now served from the frontend directory, so this
+// dynamic route is no longer needed.
+// app.get('/config.js', (req, res) => {
+//   res.type('application/javascript');
+//   res.send(`window.APP_CONFIG = ${JSON.stringify(config)};`);
+// });
 app.use(express.static(path.join(__dirname, '..', 'frontend')));
 app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, '..', 'frontend', req.url));


### PR DESCRIPTION
## Summary
- provide `frontend/config.js` with Supabase credentials and password
- remove dynamic `/config.js` endpoint in server
- ensure teacher dashboard keeps loading the static file before `teacher.js`

## Testing
- `node server/index.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6868f7ab88c883319bc02e9cccea745a