### PR TITLE
Add build script for injecting config

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ For client-side fallback, you can add JavaScript redirect if needed.
 
 Environment Variables
 ---------------------
-The server injects configuration values into the frontend via `/config.js`.
-Set these variables before running `npm start`:
+Configuration values are injected into `frontend/config.js` using the build
+script. Set these variables and run `npm run build` before starting the server
+or uploading the static site:
 
 ```
 SUPABASE_URL      your Supabase project URL
 SUPABASE_KEY      your Supabase service key
 TEACHER_PASSWORD  password required for the teacher dashboard
 ```
+
+When hosting the `frontend` folder on a static service, run `npm run build`
+locally so that `frontend/config.js` contains your credentials before
+uploading the site.
 
 These variables are **not** committed to the repository.
 # Database Schema

--- a/README.txt
+++ b/README.txt
@@ -57,13 +57,18 @@ For client-side fallback, you can add JavaScript redirect if needed.
 
 Environment Variables
 ---------------------
-The server injects configuration values into the frontend via `/config.js`.
-Set these variables before running `npm start`:
+Configuration values are injected into `frontend/config.js` using the build
+script. Set these variables and run `npm run build` before starting the server
+or uploading the static site:
 
 ```
 SUPABASE_URL      your Supabase project URL
 SUPABASE_KEY      your Supabase service key
 TEACHER_PASSWORD  password required for the teacher dashboard
 ```
+
+When hosting the `frontend` folder on a static service, run `npm run build`
+locally so that `frontend/config.js` contains your credentials before
+uploading the site.
 
 These variables are **not** committed to the repository.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
   "name": "hamdeni-platform",
   "version": "1.0.0",
-  "scripts": { "start": "node server/index.js" },
-  "dependencies": { "express": "^4.18.2" }
+  "scripts": {
+    "start": "node server/index.js",
+    "build": "node scripts/generate-config.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
 }

--- a/scripts/generate-config.js
+++ b/scripts/generate-config.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const path = require('path');
+
+const { SUPABASE_URL, SUPABASE_KEY, TEACHER_PASSWORD } = process.env;
+
+if (!SUPABASE_URL || !SUPABASE_KEY || !TEACHER_PASSWORD) {
+  console.error('SUPABASE_URL, SUPABASE_KEY and TEACHER_PASSWORD must be set');
+  process.exit(1);
+}
+
+const config = { SUPABASE_URL, SUPABASE_KEY, TEACHER_PASSWORD };
+const dest = path.join(__dirname, '..', 'frontend', 'config.js');
+
+fs.writeFileSync(dest, `window.APP_CONFIG = ${JSON.stringify(config, null, 2)};\n`);
+console.log(`Config written to ${dest}`);


### PR DESCRIPTION
## Summary
- generate `frontend/config.js` using env vars
- document build step in both READMEs
- expose a `build` npm script

## Testing
- `SUPABASE_URL=https://test-url SUPABASE_KEY=key123 TEACHER_PASSWORD=pass node scripts/generate-config.js`

------
https://chatgpt.com/codex/tasks/task_e_686906562fac8331873ef08a128baafc