### PR TITLE
Improve dashboard error handling

### DIFF
--- a/frontend/a/points/p1/layer1.html
+++ b/frontend/a/points/p1/layer1.html
@@ -290,35 +290,41 @@
   }
 
   async function updateProgress() {
-    const { error } = await supabase
-      .from("a_theory_progress")
-      .upsert({
-        studentid: student_id,
-        point_id: point_id,
-        layer1_done: true
-      }, { onConflict: ['studentid', 'point_id'] });
+    try {
+      const { error } = await supabase
+        .from("a_theory_progress")
+        .upsert({
+          studentid: student_id,
+          point_id: point_id,
+          layer1_done: true
+        }, { onConflict: ['studentid', 'point_id'] });
 
-    if (error) {
-      alert("❌ Failed to update progress.");
-      console.error(error);
+      if (error) throw error;
+      return true;
+    } catch (err) {
+      alert("❌ Failed to update progress. Please check your connection or contact your teacher.");
+      console.error("updateProgress error", err);
       return false;
     }
-    return true;
   }
 
   async function sendFeedback(feedback_type, comment = "") {
-    const { error } = await supabase
-      .from("a_theory_feedback")
-      .insert([{
-        studentid: student_id,
-        point_id: point_id,
-        layer: "layer1",
-        feedback_type,
-        comment
-      }]);
+    try {
+      const { error } = await supabase
+        .from("a_theory_feedback")
+        .insert([
+          {
+            studentid: student_id,
+            point_id: point_id,
+            layer: "layer1",
+            feedback_type,
+            comment
+          }
+        ]);
 
-    if (error) {
-      console.error("❌ Feedback insert error:", error);
+      if (error) throw error;
+    } catch (err) {
+      console.error("❌ Feedback insert error:", err);
     }
   }
 

--- a/frontend/teacher/teacher-dashboard.html
+++ b/frontend/teacher/teacher-dashboard.html
@@ -21,6 +21,7 @@
       <option value="IGCSE">IGCSE</option>
     </select>
     <button id="load-students">Filter Students</button>
+    <span id="load-msg"></span>
   </div>
 
   <div class="dashboard-content">

--- a/frontend/teacher/teacher.js
+++ b/frontend/teacher/teacher.js
@@ -21,13 +21,27 @@ let programmingLevels = [];
 
 document.getElementById('load-students').onclick = async () => {
   selectedPlatform = document.getElementById('platform').value;
-  const { data: students } = await supabase
+  const { data: students, error } = await supabase
     .from('students')
     .select('*')
     .eq('platform', selectedPlatform);
 
   const list = document.getElementById('student-list');
+  const msg = document.getElementById('load-msg');
+  msg.textContent = '';
   list.innerHTML = '';
+
+  if (error) {
+    console.error('Failed to fetch students:', error);
+    msg.textContent = '❌ Unable to load students.';
+    return;
+  }
+
+  if (!students || students.length === 0) {
+    msg.textContent = 'No students found.';
+    return;
+  }
+
   students.forEach(s => {
     const li = document.createElement('li');
     li.textContent = s.username;


### PR DESCRIPTION
## Summary
- handle Supabase errors on progress updates
- surface feedback insert errors
- show message when filtering students fails

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68698079ea28833195cf4a7142ff53ac