### PR TITLE
Fix progress update table

### DIFF
--- a/frontend/a/points/p1/layer1.html
+++ b/frontend/a/points/p1/layer1.html
@@ -290,22 +290,32 @@
   }
 
   async function updateProgress() {
-    try {
-      const { error } = await supabase
-        .from("a_theory_progress")
-        .upsert({
-          studentid: student_id,
-          point_id: point_id,
-          layer1_done: true
-        }, { onConflict: ['studentid', 'point_id'] });
+    const platform = localStorage.getItem("platform");
+    const student_id = localStorage.getItem("student_id");
 
-      if (error) throw error;
-      return true;
-    } catch (err) {
-      alert("❌ Failed to update progress. Please check your connection or contact your teacher.");
-      console.error("updateProgress error", err);
+    if (!student_id || !platform) {
+      alert("❌ Missing student information. Please log in again.");
       return false;
     }
+
+    const table = `${platform}_theory_progress`;
+
+    const { error } = await supabase
+      .from(table)
+      .upsert({
+        studentid: student_id,
+        point_id: point_id,
+        layer1_done: true
+      }, { onConflict: ['studentid', 'point_id'] });
+
+    if (error) {
+      console.error("❌ Supabase Error:", error);
+      alert(`❌ Failed to update progress: ${error.message}`);
+      return false;
+    }
+
+    console.log("✅ Progress updated in table:", table);
+    return true;
   }
 
   async function sendFeedback(feedback_type, comment = "") {

--- a/frontend/a/points/p1/quiz.js
+++ b/frontend/a/points/p1/quiz.js
@@ -67,7 +67,9 @@ function checkAnswers(questions) {
     startQuiz(incorrect);
   }
 async function sendProgress() {
-  await supabase.from("a_theory_progress").upsert({
+  const platform = localStorage.getItem("platform");
+  const table = `${platform}_theory_progress`;
+  await supabase.from(table).upsert({
     studentid: studentId,
     point_id: pointId,
     layer2_done: true


### PR DESCRIPTION
## Summary
- update progress update logic in p1 layer1.html to use the student's platform when choosing the Supabase table
- ensure quiz progress in p1 also writes to the platform-specific table

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869846e5be48331a93a621878eebc33