### PR TITLE
fix: hook layer1 buttons to module script

### DIFF
--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -345,6 +345,7 @@
       window.location.href = "layer2.html";
     }
   }
+  window.markClear = markClear;
 
   async function markConfused() {
     if (await updateProgress()) {
@@ -352,10 +353,12 @@
       window.location.href = "layer2.html";
     }
   }
+  window.markConfused = markConfused;
 
   function showHelp() {
     document.getElementById("help-section").style.display = "block";
   }
+  window.showHelp = showHelp;
 
   async function submitHelp() {
     const comment = document.getElementById("unclear").value.trim();
@@ -369,6 +372,7 @@
       window.location.href = "layer2.html";
     }
   }
+  window.submitHelp = submitHelp;
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- export markClear, markConfused, showHelp and submitHelp via `window`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686a50a2a6c88331bb3fbf9b185928e6