### PR TITLE
Fix Supabase table name mapping

### DIFF
--- a/a/modules/theoryRenderer.js
+++ b/a/modules/theoryRenderer.js
@@ -77,7 +77,12 @@ export async function renderTheoryPoints() {
 
 async function fetchProgress(studentId) {
   const platform = localStorage.getItem('platform');
-  const table = `${platform}_theory_progress`;
+  const tables = {
+    A_Level: 'a_theory_progress',
+    AS_Level: 'as_theory_progress',
+    IGCSE: 'igcse_theory_progress'
+  };
+  const table = tables[platform];
   const url = `${SUPABASE_URL}/rest/v1/${table}?select=*&studentid=eq.${studentId}`;
 
   const res = await fetch(url, {

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -299,7 +299,12 @@
       return false;
     }
 
-    const table = `${platform}_theory_progress`;
+    const tables = {
+      A_Level: 'a_theory_progress',
+      AS_Level: 'as_theory_progress',
+      IGCSE: 'igcse_theory_progress'
+    };
+    const table = tables[platform];
 
     const { error } = await supabase
       .from(table)

--- a/a/points/p1/modules/supabase.js
+++ b/a/points/p1/modules/supabase.js
@@ -5,7 +5,12 @@ const client = window.supabase;
 async function updateTheoryProgress(pointId, layer) {
   const student_id = localStorage.getItem("student_id");
   const platform = localStorage.getItem("platform");
-  const table = `${platform}_theory_progress`;
+  const tables = {
+    A_Level: 'a_theory_progress',
+    AS_Level: 'as_theory_progress',
+    IGCSE: 'igcse_theory_progress'
+  };
+  const table = tables[platform];
   const layerColumn = `layer${layer}_done`;
 
   console.log("📡 Supabase UPSERT:", { table, pointId, layerColumn });

--- a/a/points/p1/quiz.js
+++ b/a/points/p1/quiz.js
@@ -69,7 +69,12 @@ function checkAnswers(questions) {
   }
 async function sendProgress() {
   const platform = localStorage.getItem("platform");
-  const table = `${platform}_theory_progress`;
+  const tables = {
+    A_Level: 'a_theory_progress',
+    AS_Level: 'as_theory_progress',
+    IGCSE: 'igcse_theory_progress'
+  };
+  const table = tables[platform];
   await supabase.from(table).upsert({
     studentid: studentId,
     point_id: pointId,


### PR DESCRIPTION
## Summary
- map platform names to actual Supabase tables in quiz and renderer modules
- ensure table mapping in p1 progress updates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686a5744a48883319a8434e17cf83a9a