### PR TITLE
Fix layer2 quiz initialization

### DIFF
--- a/a/points/p1/layer2.html
+++ b/a/points/p1/layer2.html
@@ -224,7 +224,9 @@
   📧 Contact Dr. Hamdeni at <a href="mailto:hamdeni.chamseddine@gmail.com">hamdeni.chamseddine@gmail.com</a>
 </footer>
 
-<script src="quiz.js"></script>
+<!-- Ensure the quiz script runs after the module above has created
+     `window.supabase` by deferring its execution -->
+<script src="quiz.js" defer></script>
 
 </body>
 </html>

--- a/a/points/p1/quiz.js
+++ b/a/points/p1/quiz.js
@@ -1,6 +1,9 @@
 const SUPABASE_URL = "https://tsmzmuclrnyryuvanlxl.supabase.co";
 const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
-const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_KEY);
+// `window.supabase` already holds the Supabase client instance created in
+// `layer2.html`. Just reuse it instead of trying to call `createClient` again
+// on an undefined object.
+const supabase = window.supabase;
 const studentId = localStorage.getItem("student_id");
 const pointId = location.pathname.split("/").find(p => p.startsWith("p")).toUpperCase();
 


### PR DESCRIPTION
## Summary
- reuse `window.supabase` client in `quiz.js`
- defer quiz script so Supabase client is available first

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686a60aa998c8331a61953b4eee74886