### PR TITLE
Refine layer1 layout

### DIFF
--- a/a/points/p1/docs.json
+++ b/a/points/p1/docs.json
@@ -1,6 +1,0 @@
-{
-  "P1": {
-    "url": "https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true",
-    "height": 2000
-  }
-}

--- a/a/points/p1/docs.json
+++ b/a/points/p1/docs.json
@@ -1,0 +1,6 @@
+{
+  "P1": {
+    "url": "https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true",
+    "height": 2000
+  }
+}

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -290,29 +290,28 @@
         }
       });
 
-    fetch("docs.json")
-      .then(res => res.json())
-      .then(docs => {
-        if (docs[point_id]) {
-          const { url, height } = docs[point_id];
-          const frame = document.getElementById("doc-frame");
-          frame.src = url;
-          if (height) frame.height = height;
-        }
-      });
-
     fetch("videos.json")
       .then(res => res.json())
-      .then(videos => {
-        if (videos[point_id] && videos[point_id].length > 0) {
-          document.getElementById("video-section").style.display = "block";
-          const container = document.getElementById("videos-container");
-          videos[point_id].forEach(video => {
-            const wrapper = document.createElement("div");
-            wrapper.innerHTML = video.iframe;
-            wrapper.style.marginBottom = "20px";
-            container.appendChild(wrapper);
-          });
+      .then(data => {
+        if (data[point_id]) {
+          const { videos = [], doc } = data[point_id];
+
+          if (doc) {
+            const frame = document.getElementById("doc-frame");
+            frame.src = doc.url;
+            if (doc.height) frame.height = doc.height;
+          }
+
+          if (videos.length > 0) {
+            document.getElementById("video-section").style.display = "block";
+            const container = document.getElementById("videos-container");
+            videos.forEach(video => {
+              const wrapper = document.createElement("div");
+              wrapper.innerHTML = video.iframe;
+              wrapper.style.marginBottom = "20px";
+              container.appendChild(wrapper);
+            });
+          }
         }
       });
   }

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -19,7 +19,7 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
-      padding: 15px 30px;
+      padding: 10px 20px;
       background-color: #003366;
       color: white;
     }
@@ -39,55 +39,52 @@
       font-size: 1.8em;
     }
 
-    .header-center p {
-      margin: 3px 0;
+    .info-line {
+      display: flex;
+      justify-content: center;
+      gap: 20px;
+      margin-top: 3px;
       font-size: 1em;
       color: #f0f0f0;
     }
 
     .logo {
+      height: 45px;
+    }
+
+    #maarif-logo {
       height: 55px;
     }
 
     main {
-      display: flex;
       padding: 30px;
-      gap: 20px;
     }
 
-    .doc-container {
-      flex: 0 0 60%;
-      max-width: 100%;
-      display: flex;
-      flex-direction: column;
-      padding-right: 20px;
-      border-right: 2px solid #ccc;
+    .grid-container {
+      display: grid;
+      grid-template-columns: 7fr 3fr;
+      grid-template-rows: auto auto;
+      gap: 30px;
     }
 
-    .notes-container {
-      flex: 0 0 40%;
-      display: flex;
-      flex-direction: column;
-      padding-left: 20px;
+    .cell {
+      background: #fff;
+      padding: 30px;
+      border-radius: 8px;
+      box-shadow: 0 0 5px rgba(0,0,0,0.1);
     }
 
-    .notes-container label {
-      font-weight: bold;
-      margin-bottom: 10px;
-    }
-
-    .notes-container textarea {
+    .editable-note {
       width: 100%;
-      height: 100%;
-      flex: 1;
+      min-height: 400px;
+      border: 1px solid #aaa;
+      border-radius: 6px;
       padding: 15px;
       font-size: 1em;
-      border-radius: 6px;
-      border: 1px solid #aaa;
-      resize: vertical;
     }
 
     .section-title {
+      display: inline-block;
       font-weight: bold;
       margin: 15px 0 8px;
       font-size: 1.2em;
@@ -110,14 +107,19 @@
       margin-bottom: 20px;
     }
 
+    .videos iframe {
+      height: 250px;
+    }
+
     #official-notes {
-      overflow-x: hidden;
+      overflow: hidden;
     }
 
     .official-doc {
       width: calc(100% / 1.1);
       transform: scale(1.1);
       transform-origin: top left;
+      border: none;
     }
 
     .actions {
@@ -199,13 +201,16 @@
 
     <div class="header-left">
       <a href="../../dashboard.html">
-        <img src="../../../images/maarifLOGO.png" class="logo" />
+        <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>
     <div class="header-center">
-      <h1>Theoretical Foundation</h1>
-      <p id="student-name"></p>
-      <p id="platform-name"></p>
+      <h1>Layer 1: Theoretical Foundation</h1>
+      <div class="info-line">
+        <span id="point-title"></span>
+        <span id="student-name"></span>
+        <span id="platform-name"></span>
+      </div>
     </div>
     <div class="header-right" style="text-align:right;">
       <img src="../../../images/cambridge.png" class="logo" />
@@ -218,24 +223,25 @@
   </div>
 
   <main id="content-area" style="display: none;">
-    <div class="doc-container">
-      <div class="section-title">📌 Syllabus Points</div>
-      <img src="syllabus.png" alt="Syllabus Image" style="max-width: 100%; margin-bottom: 20px;" />
-
-      <div class="section-title">📄 Official Theory Notes</div>
-      <div id="official-notes">
-        <iframe class="official-doc" src="https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true" height="2000" scrolling="no"></iframe>
+    <div class="grid-container">
+      <div class="cell syllabus">
+        <div class="section-title">📌 Syllabus Points</div>
+        <img src="syllabus.png" alt="Syllabus Image" style="max-width: 100%; margin-bottom: 20px;" />
       </div>
-    </div>
-
-    <div class="notes-container">
-      <div id="video-section" style="display:none;">
-        <label class="section-title">🎥 Related Videos</label>
+      <div id="video-section" class="cell videos" style="display:none;">
+        <div class="section-title">🎥 Related Videos</div>
         <div id="videos-container"></div>
       </div>
-
-      <label class="section-title">📝 Your Personal Notes</label>
-      <textarea placeholder="Write your own notes or summary about the theory..."></textarea>
+      <div class="cell theory">
+        <div class="section-title">📄 Mr. Hamdeni's Theory Notes</div>
+        <div id="official-notes">
+          <iframe id="doc-frame" class="official-doc" scrolling="no"></iframe>
+        </div>
+      </div>
+      <div class="cell personal">
+        <div class="section-title" id="personal-title">📝 Personal Notes</div>
+        <div id="personal-notes" class="editable-note" contenteditable="true" placeholder="Write your own notes or summary about the theory..."></div>
+      </div>
     </div>
   </main>
 
@@ -272,7 +278,28 @@
   } else {
     document.getElementById("student-name").textContent = "👤 " + student_name;
     document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
-    document.getElementById("content-area").style.display = "flex";
+    document.getElementById("personal-title").textContent = `📝 ${student_name}'s Personal Notes`;
+    document.getElementById("content-area").style.display = "block";
+
+    fetch("../index.json")
+      .then(res => res.json())
+      .then(list => {
+        const found = list.find(p => p.id.toLowerCase() === point_id.toLowerCase());
+        if (found) {
+          document.getElementById("point-title").textContent = "📍 " + found.title;
+        }
+      });
+
+    fetch("docs.json")
+      .then(res => res.json())
+      .then(docs => {
+        if (docs[point_id]) {
+          const { url, height } = docs[point_id];
+          const frame = document.getElementById("doc-frame");
+          frame.src = url;
+          if (height) frame.height = height;
+        }
+      });
 
     fetch("videos.json")
       .then(res => res.json())

--- a/a/points/p1/videos.json
+++ b/a/points/p1/videos.json
@@ -1,8 +1,14 @@
 {
-  "P1": [
-    {
-      "title": "Intro to File Organization",
-      "iframe": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/_kxf_Ztyfq8?si=MLHDXWn83dJ0HDnX\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
-    }
-  ]
+  "P1": {
+    "doc": {
+      "url": "https://docs.google.com/document/d/e/2PACX-1vRvBHZuPzhu5e1ZqIfFISG5htJXqqkO_mBA8INcH053tFI9vyGlNwQQLkgZluFDqKxLN2IOAptPXPvJ/pub?embedded=true",
+      "height": 2000
+    },
+    "videos": [
+      {
+        "title": "Intro to File Organization",
+        "iframe": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/_kxf_Ztyfq8?si=MLHDXWn83dJ0HDnX\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- widen first column to occupy 70% of the grid
- inline blue headings and bump cell padding
- enlarge Maarif logo and rearrange info line
- cap related video height and show full theory doc
- fetch word doc URL and height from new JSON file

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a9a326ee08331806e5ede154854b3