### PR TITLE
Switch theory progress to reached_layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,10 +371,7 @@ Legend: PK=Primary Key, FK=Foreign Key, Nullable=YES if column allows NULL.
 | id | uuid | NO | gen_random_uuid() | PK |  | null(null) |
 | studentid | text | NO | null |  | UQ | null(null) |
 | point_id | text | NO | null |  | UQ | null(null) |
-| layer1_done | boolean | YES | false |  |  | null(null) |
-| layer2_done | boolean | YES | false |  |  | null(null) |
-| layer3_done | boolean | YES | false |  |  | null(null) |
-| layer4_done | boolean | YES | false |  |  | null(null) |
+| reached_layer | integer | NO | 0 |  |  | null(null) |
 
 ### Table `as_programming_levels`
 | Column | Type | Nullable | Default | PK | Unique | Foreign Key |

--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -31,7 +31,7 @@ export async function fetchProgressCounts() {
 
   try {
     const [tRes, lRes] = await Promise.all([
-      fetch(`${base}/${theoryTable}?select=layer4_done&studentid=eq.${studentId}`, {
+      fetch(`${base}/${theoryTable}?select=reached_layer&studentid=eq.${studentId}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
@@ -48,7 +48,7 @@ export async function fetchProgressCounts() {
     const tData = await tRes.json();
     const lData = await lRes.json();
 
-    const passedPoints = tData.filter(r => r.layer4_done).length;
+    const passedPoints = tData.filter(r => r.reached_layer === 4).length;
     const passedLevels = lData.filter(r => r.level_done).length;
     const result = { points: passedPoints, levels: passedLevels };
     console.log('[supabaseModule] Progress counts', result);

--- a/a/modules/theoryRenderer.js
+++ b/a/modules/theoryRenderer.js
@@ -44,12 +44,8 @@ export async function renderTheoryPoints() {
   points.forEach(point => {
     console.debug('[theoryRenderer] Rendering point', point.id);
     const entry = progressMap[point.id.toLowerCase()] || {};
-    const layerStates = [
-      entry.layer1_done ? "green" : "grey",
-      entry.layer2_done ? "green" : "grey",
-      entry.layer3_done ? "green" : "grey",
-      entry.layer4_done ? "green" : "grey"
-    ];
+    const reached = entry.reached_layer || 0;
+    const layerStates = [1, 2, 3, 4].map(n => reached >= n ? "green" : "grey");
 
     const box = document.createElement("div");
     box.className = "theory-box theory-clickable";

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -337,7 +337,7 @@
       .upsert({
         studentid: student_id,
         point_id: point_id,
-        layer1_done: true
+        reached_layer: 1
       }, { onConflict: ['studentid', 'point_id'] });
 
     if (error) {

--- a/a/points/p1/modules/supabase.js
+++ b/a/points/p1/modules/supabase.js
@@ -11,16 +11,14 @@ async function updateTheoryProgress(pointId, layer) {
     IGCSE: 'igcse_theory_progress'
   };
   const table = tables[platform];
-  const layerColumn = `layer${layer}_done`;
-
-  console.log("📡 Supabase UPSERT:", { table, pointId, layerColumn });
+  console.log("📡 Supabase UPSERT:", { table, pointId, reached_layer: layer });
 
   const { error } = await client
     .from(table)
     .upsert({
       studentid: student_id,
       point_id: pointId,
-      [layerColumn]: true
+      reached_layer: layer
     }, { onConflict: ['studentid', 'point_id'] });
 
   if (error) console.error("❌ Supabase Error:", error);

--- a/a/points/p1/quiz.js
+++ b/a/points/p1/quiz.js
@@ -5,7 +5,10 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 // on an undefined object.
 const supabase = window.supabase;
 const studentId = localStorage.getItem("student_id");
-const pointId = location.pathname.split("/").find(p => p.startsWith("p")).toUpperCase();
+const pointId = (location.pathname
+  .split("/")
+  .find(p => /^p\d+$/i.test(p)) || "")
+  .toUpperCase();
 
 fetch("quiz.json")
   .then(r => r.json())
@@ -99,7 +102,7 @@ async function sendProgress() {
   await supabase.from(table).upsert({
     studentid: studentId,
     point_id: pointId,
-    layer2_done: true
+    reached_layer: 2
   }, { onConflict: ['studentid', 'point_id'] });
 }
 

--- a/a/points/p10/quiz.js
+++ b/a/points/p10/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p11/quiz.js
+++ b/a/points/p11/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p12/quiz.js
+++ b/a/points/p12/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p13/quiz.js
+++ b/a/points/p13/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p14/quiz.js
+++ b/a/points/p14/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p15/quiz.js
+++ b/a/points/p15/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p2/quiz.js
+++ b/a/points/p2/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p3/quiz.js
+++ b/a/points/p3/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p4/quiz.js
+++ b/a/points/p4/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p5/quiz.js
+++ b/a/points/p5/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p6/quiz.js
+++ b/a/points/p6/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p7/quiz.js
+++ b/a/points/p7/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p8/quiz.js
+++ b/a/points/p8/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;

--- a/a/points/p9/quiz.js
+++ b/a/points/p9/quiz.js
@@ -79,7 +79,9 @@ function showResult(correct, total, questions) {
 function sendProgress() {
   const student_id = localStorage.getItem("student_id");
   const path = window.location.pathname;
-  const point_id = path.split("/").find(p => p.startsWith("p"));
+  const point_id = path
+    .split("/")
+    .find(p => /^p\d+$/i.test(p));
   const platform = localStorage.getItem("platform");
   const tables = {
     A_Level: "a_theory_progress",
@@ -97,7 +99,7 @@ function sendProgress() {
     body: JSON.stringify({
       studentid: student_id,
       point_id: point_id.toUpperCase(),
-      layer2_done: true
+      reached_layer: 2
     })
 function shuffle(array) {
   let currentIndex = array.length, randomIndex;


### PR DESCRIPTION
## Summary
- track theory progress with `reached_layer`
- color progress bar segments based on highest reached layer
- update general progress fetch logic
- adjust point scripts that upsert progress
- document new `reached_layer` column
- fix progress point_id detection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c1f9fb883318c0f4c96788f5849