### PR TITLE
Increase teacher label width

### DIFF
--- a/teacher/teacher.css
+++ b/teacher/teacher.css
@@ -83,7 +83,7 @@ header {
 
 .point-label,
 .level-label {
-  width: 140px;
+  width: 200px;
 }
 
 /* Modal styles */


### PR DESCRIPTION
## Summary
- adjust `.point-label` and `.level-label` widths in teacher dashboard styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d7effa50083318fa5cf079699c8ab