### PR TITLE
Fix teacher dashboard progress display

### DIFF
--- a/teacher/teacher-dashboard.html
+++ b/teacher/teacher-dashboard.html
@@ -32,12 +32,9 @@
 
     <main class="student-progress">
       <h3 id="student-title">Select a student to view progress</h3>
-      <section id="levels-section">
-        <h3>Levels</h3>
-        <div id="programming-progress"></div>
-      </section>
       <div class="progress-columns">
         <div id="theory-progress"></div>
+        <div id="programming-progress"></div>
       </div>
       <button id="save-progress" class="save-btn" style="display: none;">Save Progress</button>
       <div id="save-msg"></div>

--- a/teacher/teacher.css
+++ b/teacher/teacher.css
@@ -55,10 +55,6 @@ header {
   margin-bottom: 15px;
 }
 
-/* Section for programming levels */
-#levels-section {
-  margin-bottom: 20px;
-}
 
 #save-msg {
   font-size: 0.95em;

--- a/teacher/teacher.js
+++ b/teacher/teacher.js
@@ -136,7 +136,9 @@ async function renderTheory(data) {
       checkbox.type = 'checkbox';
       checkbox.dataset.point = id;
       checkbox.dataset.layer = i;
-      const found = (data || []).find(d => d.point_id === id);
+      const found = (data || []).find(
+        d => d.point_id && d.point_id.toLowerCase() === id.toLowerCase()
+      );
       if (found) {
         if (usesReachedLayer()) {
           if (Number(found.reached_layer) >= i) checkbox.checked = true;
@@ -200,7 +202,11 @@ document.getElementById('save-progress').onclick = async () => {
       if (usesReachedLayer()) {
         await supabase
           .from(tTable)
-          .upsert({ username: selectedStudent, point_id: point, reached_layer });
+          .upsert({
+            username: selectedStudent,
+            point_id: point.toUpperCase(),
+            reached_layer
+          });
       } else {
         const update = { username: selectedStudent, point_id: point };
         for (let i = 1; i <= 4; i++) {


### PR DESCRIPTION
## Summary
- display theory progress regardless of point ID casing
- sync saved point IDs with existing Supabase entries
- move the programming progress next to theory progress
- remove unused teacher CSS rule

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef6e6b8048331a839468d7dd450d5