### PR TITLE
Fix progress fetching with encoded usernames

### DIFF
--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -31,13 +31,13 @@ export async function fetchProgressCounts() {
 
   try {
     const [tRes, lRes] = await Promise.all([
-      fetch(`${base}/${theoryTable}?select=reached_layer&username=eq.${username}`, {
+      fetch(`${base}/${theoryTable}?select=reached_layer&username=eq.${encodeURIComponent(username)}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
         }
       }),
-      fetch(`${base}/${levelTable}?select=level_done&username=eq.${username}`, {
+      fetch(`${base}/${levelTable}?select=level_done&username=eq.${encodeURIComponent(username)}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY

--- a/a/modules/theoryRenderer.js
+++ b/a/modules/theoryRenderer.js
@@ -82,7 +82,7 @@ async function fetchProgress(username) {
     IGCSE: 'igcse_theory_progress'
   };
   const table = tables[platform];
-  const url = `${SUPABASE_URL}/rest/v1/${table}?select=*&username=eq.${username}`;
+  const url = `${SUPABASE_URL}/rest/v1/${table}?select=*&username=eq.${encodeURIComponent(username)}`;
 
   const res = await fetch(url, {
     headers: {
@@ -91,5 +91,4 @@ async function fetchProgress(username) {
     }
   });
 
-  const data = await res.json();
-  return { data };}
+  const data = await res.json();  return { data };}


### PR DESCRIPTION
## Summary
- properly URL encode usernames when loading progress from Supabase

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef99ea70c8331816a52b3bf91dea2