### PR TITLE
Adapt progress to reached_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,10 +340,8 @@ Legend: PK=Primary Key, FK=Foreign Key, Nullable=YES if column allows NULL.
 ### Table `a_programming_progress`
 | Column | Type | Nullable | Default | PK | Unique | Foreign Key |
 |--------|------|----------|---------|----|--------|-------------|
-| id | uuid | NO | gen_random_uuid() | PK |  | null(null) |
-| username | text | NO | null |  | UQ | null(null) |
-| level_number | integer | NO | null |  | UQ | null(null) |
-| level_done | boolean | YES | false |  |  | null(null) |
+| studentid | text | NO | null | PK |  | students.username |
+| reached_level | integer | NO | 0 |  |  | null |
 
 ### Table `a_theory_feedback`
 | Column | Type | Nullable | Default | PK | Unique | Foreign Key |

--- a/a/modules/levelRenderer.js
+++ b/a/modules/levelRenderer.js
@@ -1,4 +1,6 @@
 
+import { fetchProgressCounts } from "./supabase.js";
+
 export const levels = [
     { title: "Introduction", id: "level1", status: "locked" },
     { title: "Basic I/O", id: "level2", status: "locked" },
@@ -18,7 +20,7 @@ export const levels = [
     { title: "Final Project", id: "level16", status: "locked" }
   ];
 
-export function renderProgrammingLevels() {
+export async function renderProgrammingLevels() {
   console.log('[levelRenderer] Rendering programming levels');
   const container = document.getElementById("programming-levels");
   if (!container) {
@@ -26,17 +28,21 @@ export function renderProgrammingLevels() {
     return;
   }
 
+  const { levels: reached = 0 } = await fetchProgressCounts();
 
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);
     const box = document.createElement("div");
-    box.className = `level-box ${level.status}`;
+    let status = 'locked';
+    if (index + 1 <= reached) status = 'passed';
+    else if (index === reached) status = 'unlocked';
+    box.className = `level-box ${status}`;
     box.dataset.level = index + 1;
 
     let icon = "";
-    if (level.status === "locked") icon = "\uD83D\uDD12"; // 🔒
-    else if (level.status === "unlocked") icon = "\uD83D\uDD13"; // 🔓
-    else if (level.status === "passed") icon = "\u2705"; // ✅
+    if (status === "locked") icon = "\uD83D\uDD12"; // 🔒
+    else if (status === "unlocked") icon = "\uD83D\uDD13"; // 🔓
+    else if (status === "passed") icon = "\u2705"; // ✅
 
     box.innerHTML = `
       <span class="level-icon">${icon}</span>

--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -21,7 +21,6 @@ function tableName(platform, type) {
 export async function fetchProgressCounts() {
   console.log('[supabaseModule] Fetching progress counts');
   const username = localStorage.getItem('username');
-  const studentId = localStorage.getItem('student_id');
   const platform = localStorage.getItem('platform');
 
   if (!username || !platform) return { points: 0, levels: 0 };
@@ -38,7 +37,7 @@ export async function fetchProgressCounts() {
           Authorization: 'Bearer ' + SUPABASE_KEY
         }
       }),
-      fetch(`${base}/${levelTable}?select=level_done&${platform === 'A_Level' ? 'studentid' : 'username'}=eq.${encodeURIComponent(platform === 'A_Level' ? studentId : username)}`, {
+      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' ? 'reached_level' : 'level_done'}&${platform === 'A_Level' ? 'studentid' : 'username'}=eq.${encodeURIComponent(username)}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
@@ -50,7 +49,12 @@ export async function fetchProgressCounts() {
     const lData = await lRes.json();
 
     const passedPoints = tData.filter(r => r.reached_layer === 4).length;
-    const passedLevels = lData.filter(r => r.level_done).length;
+    let passedLevels = 0;
+    if (platform === 'A_Level') {
+      passedLevels = lData.length ? lData[0].reached_level : 0;
+    } else {
+      passedLevels = lData.filter(r => r.level_done).length;
+    }
     const result = { points: passedPoints, levels: passedLevels };
     console.log('[supabaseModule] Progress counts', result);
     return result;


### PR DESCRIPTION
## Summary
- simplify `a_programming_progress` handling
- compute dashboard progress using `reached_level`
- update teacher dashboard to update/display `reached_level`
- insert programming progress row when creating a new student
- document new structure of `a_programming_progress`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870433f36b08331ba300a18a1d4915d