### PR TITLE
Fix A Level progress saving

### DIFF
--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -37,7 +37,7 @@ export async function fetchProgressCounts() {
           Authorization: 'Bearer ' + SUPABASE_KEY
         }
       }),
-      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' ? 'reached_level' : 'level_done'}&${platform === 'A_Level' ? 'studentid' : 'username'}=eq.${encodeURIComponent(username)}`, {
+      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' ? 'reached_level' : 'level_done'}&username=eq.${encodeURIComponent(username)}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY

--- a/teacher/teacher.js
+++ b/teacher/teacher.js
@@ -96,12 +96,10 @@ async function loadStudentProgress(student) {
   }
 
   try {
-    const column = selectedPlatform === 'A_Level' ? 'studentid' : 'username';
-    const value = username;
     const { data: lData, error: lErr } = await supabase
       .from(lTable)
       .select('*')
-      .eq(column, value);
+      .eq('username', username);
     if (lErr) throw lErr;
     renderLevels(lData || []);
   } catch (err) {
@@ -248,7 +246,7 @@ document.getElementById('save-progress').onclick = async () => {
       await supabase
         .from(lTable)
         .update({ reached_level: reached })
-        .eq('studentid', selectedStudent.username);
+        .eq('username', selectedStudent.username);
     } catch (err) {
       console.error('[teacher] Failed updating reached_level', err);
     }
@@ -342,7 +340,7 @@ if (addStudentForm) {
 
       if (platform === 'A_Level') {
         await supabase.from('a_programming_progress').insert({
-          studentid: username,
+          username: username,
           reached_level: 0
         });
       }


### PR DESCRIPTION
## Summary
- ensure teacher dashboard uses the `username` column when loading and saving A Level programming progress
- correct creation of initial programming progress entry
- adjust supabase helper query

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68717023b984833183e3f76e5d886bc0