### PR TITLE
Adjust level colors based on reached level

### DIFF
--- a/a/modules/levelRenderer.js
+++ b/a/modules/levelRenderer.js
@@ -34,8 +34,11 @@ export async function renderProgrammingLevels() {
     console.debug('[levelRenderer] Creating level box', level.id);
     const box = document.createElement("div");
     let status = 'locked';
-    if (index + 1 <= reached) status = 'passed';
-    else if (index === reached) status = 'unlocked';
+    if (index + 1 < reached) {
+      status = 'passed';
+    } else if (index + 1 === reached) {
+      status = 'unlocked';
+    }
     box.className = `level-box ${status}`;
     box.dataset.level = index + 1;
 


### PR DESCRIPTION
## Summary
- fix level status computation when rendering programming levels

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871720d1cf4833194b5d4a94d04501f