### PR TITLE
Unify navigation button styling

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -472,6 +472,21 @@ body {
   color: #333;
   line-height: 18px;
 }
+
+/* Navigation buttons shared across layers */
+.nav-btn {
+  padding: 10px 20px;
+  background: #007bff;
+  color: #ffffff;
+  text-decoration: none;
+  border-radius: 6px;
+  margin-right: 10px;
+  transition: background 0.3s ease;
+}
+
+.nav-btn:hover {
+  background: #0056b3;
+}
 /* Footer */
 footer {
   width: 100%;

--- a/a/points/p2/layer2.html
+++ b/a/points/p2/layer2.html
@@ -8,7 +8,7 @@
 <body>
   <div class="header">Layer 2 - Quiz</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer1.html"><button>← Back to Layer 1</button></a>
+    <a href="layer1.html" class="nav-btn">← Back to Layer 1</a>
   </div>
   <div id="student-name" style="text-align:center; font-weight: bold;"></div>
   <div id="quiz-container"></div>

--- a/a/points/p2/layer3.html
+++ b/a/points/p2/layer3.html
@@ -7,12 +7,12 @@
 <body>
   <div class="header">Layer 3 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer2.html"><button>← Back to Layer 2</button></a>
+    <a href="layer2.html" class="nav-btn">← Back to Layer 2</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-  <a href="layer2.html"><button>← Previous</button></a>
-  <a href="layer4.html">Next → Layer 4</a>
+  <a href="layer2.html" class="nav-btn">← Previous</a>
+  <a href="layer4.html" class="nav-btn">Next → Layer 4</a>
   </div>
   <script type="module">
 import { supabase } from '../../../supabaseClient.js';

--- a/a/points/p2/layer4.html
+++ b/a/points/p2/layer4.html
@@ -7,11 +7,11 @@
 <body>
   <div class="header">Layer 4 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer3.html"><button>← Back to Layer 3</button></a>
+    <a href="layer3.html" class="nav-btn">← Back to Layer 3</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-    <a href="layer3.html"><button>← Previous</button></a>
+    <a href="layer3.html" class="nav-btn">← Previous</a>
   </div>
 </body>
 </html>

--- a/a/points/p3/layer2.html
+++ b/a/points/p3/layer2.html
@@ -8,7 +8,7 @@
 <body>
   <div class="header">Layer 2 - Quiz</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer1.html"><button>← Back to Layer 1</button></a>
+    <a href="layer1.html" class="nav-btn">← Back to Layer 1</a>
   </div>
   <div id="student-name" style="text-align:center; font-weight: bold;"></div>
   <div id="quiz-container"></div>

--- a/a/points/p3/layer3.html
+++ b/a/points/p3/layer3.html
@@ -7,12 +7,12 @@
 <body>
   <div class="header">Layer 3 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer2.html"><button>← Back to Layer 2</button></a>
+    <a href="layer2.html" class="nav-btn">← Back to Layer 2</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-  <a href="layer2.html"><button>← Previous</button></a>
-  <a href="layer4.html">Next → Layer 4</a>
+  <a href="layer2.html" class="nav-btn">← Previous</a>
+  <a href="layer4.html" class="nav-btn">Next → Layer 4</a>
   </div>
   <script type="module">
 import { supabase } from '../../../supabaseClient.js';

--- a/a/points/p3/layer4.html
+++ b/a/points/p3/layer4.html
@@ -7,11 +7,11 @@
 <body>
   <div class="header">Layer 4 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer3.html"><button>← Back to Layer 3</button></a>
+    <a href="layer3.html" class="nav-btn">← Back to Layer 3</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-    <a href="layer3.html"><button>← Previous</button></a>
+      <a href="layer3.html" class="nav-btn">← Previous</a>
   </div>
 </body>
 </html>

--- a/a/points/p4/layer2.html
+++ b/a/points/p4/layer2.html
@@ -8,7 +8,7 @@
 <body>
   <div class="header">Layer 2 - Quiz</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer1.html"><button>← Back to Layer 1</button></a>
+    <a href="layer1.html" class="nav-btn">← Back to Layer 1</a>
   </div>
   <div id="student-name" style="text-align:center; font-weight: bold;"></div>
   <div id="quiz-container"></div>

--- a/a/points/p4/layer3.html
+++ b/a/points/p4/layer3.html
@@ -7,12 +7,12 @@
 <body>
   <div class="header">Layer 3 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer2.html"><button>← Back to Layer 2</button></a>
+    <a href="layer2.html" class="nav-btn">← Back to Layer 2</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-  <a href="layer2.html"><button>← Previous</button></a>
-  <a href="layer4.html">Next → Layer 4</a>
+  <a href="layer2.html" class="nav-btn">← Previous</a>
+  <a href="layer4.html" class="nav-btn">Next → Layer 4</a>
   </div>
   <script type="module">
 import { supabase } from '../../../supabaseClient.js';

--- a/a/points/p4/layer4.html
+++ b/a/points/p4/layer4.html
@@ -7,11 +7,11 @@
 <body>
   <div class="header">Layer 4 - Coming Soon</div>
   <div style="text-align:left; margin:10px;">
-    <a href="layer3.html"><button>← Back to Layer 3</button></a>
+    <a href="layer3.html" class="nav-btn">← Back to Layer 3</a>
   </div>
   <div style="text-align: center; margin-top: 100px;">This content is coming soon.</div>
   <div style="text-align: center; margin: 20px;">
-    <a href="layer3.html"><button>← Previous</button></a>
+      <a href="layer3.html" class="nav-btn">← Previous</a>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add reusable `.nav-btn` style in `a/dashboard.css`
- use `.nav-btn` on layer navigation links so that "Back to Layer 2" and "Back to Layer 3" match the look of "Back to Layer 1"

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872580cfc308331b699f2cd727e71dd