### PR TITLE
Implement layer4 readiness with questions

### DIFF
--- a/a/points/p1/layer4.html
+++ b/a/points/p1/layer4.html
@@ -19,17 +19,9 @@
       color: white;
     }
     .header-left,
-    .header-right {
-      flex: 1;
-    }
-    .header-center {
-      flex: 2;
-      text-align: center;
-    }
-    .header-center h1 {
-      margin: 0;
-      font-size: 1.8em;
-    }
+    .header-right { flex: 1; }
+    .header-center { flex: 2; text-align: center; }
+    .header-center h1 { margin: 0; font-size: 1.8em; }
     .info-line {
       display: flex;
       justify-content: center;
@@ -38,14 +30,26 @@
       font-size: 1em;
       color: #f0f0f0;
     }
-    .subheading {
-      margin: 5px 0;
-      font-size: 1.2em;
-      color: #f0f0f0;
+    .subheading { margin: 5px 0; font-size: 1.2em; color: #f0f0f0; }
+    .logo { height: 55px; }
+
+    #qa-container {
+      max-width: 900px;
+      margin: auto;
     }
-    .logo {
-      height: 55px;
+    .qa-row {
+      display: flex;
+      background: #fff;
+      border: 1px solid #ccc;
+      border-radius: 8px;
+      margin-bottom: 15px;
     }
+    .qa-question, .qa-answer {
+      width: 50%;
+      padding: 15px;
+      box-sizing: border-box;
+    }
+    #ready-message { margin-top: 20px; }
   </style>
 </head>
 <body>
@@ -71,8 +75,13 @@
   <div style="text-align:left; padding:10px;">
     <a href="layer3.html" class="nav-btn">← Back to Layer 3</a>
   </div>
-  <main style="text-align:center; padding:40px;">
-    <p>Unlocked by teacher.</p>
+
+  <main style="padding:40px; text-align:center;">
+    <div id="qa-container"></div>
+    <button id="ready-btn" class="nav-btn" style="margin-top:20px;">Ready for the test</button>
+    <p id="ready-message" style="display:none;"></p>
   </main>
+
+  <script type="module" src="layer4.js"></script>
 </body>
 </html>

--- a/a/points/p1/layer4.js
+++ b/a/points/p1/layer4.js
@@ -1,0 +1,51 @@
+import { supabase } from '../../../supabaseClient.js';
+
+const studentName = localStorage.getItem('student_name');
+const username = localStorage.getItem('username');
+const platform = localStorage.getItem('platform');
+const pointId = (location.pathname.split('/')
+  .find(p => /^p\d+$/i.test(p)) || 'P1').toUpperCase();
+
+document.getElementById('point-title').textContent = pointId;
+if (studentName) {
+  document.getElementById('student-name').textContent = '👤 ' + studentName;
+}
+if (platform) {
+  document.getElementById('platform-name').textContent = '🎓 Platform: ' + platform;
+}
+
+fetch('layer4_questions.json')
+  .then(r => r.json())
+  .then(renderQuestions);
+
+function renderQuestions(questions) {
+  const container = document.getElementById('qa-container');
+  questions.forEach((q, i) => {
+    const row = document.createElement('div');
+    row.className = 'qa-row';
+    row.innerHTML = `
+      <div class="qa-question"><strong>Q${i + 1}.</strong> ${q.question}</div>
+      <div class="qa-answer">${q.answer}</div>
+    `;
+    container.appendChild(row);
+  });
+}
+
+async function markReady() {
+  const { error } = await supabase.from('a_theory_progress').upsert({
+    username,
+    point_id: pointId.toLowerCase(),
+    reached_layer: 'R'
+  }, { onConflict: ['username','point_id'] });
+
+  const msg = document.getElementById('ready-message');
+  if (error) {
+    console.error('Failed to update progress', error);
+    msg.textContent = '❌ Failed to inform the teacher.';
+  } else {
+    msg.textContent = 'The teacher has been informed that you are ready and you will sit for a validation test soon.';
+  }
+  msg.style.display = 'block';
+}
+
+document.getElementById('ready-btn').addEventListener('click', markReady);

--- a/a/points/p1/layer4_questions.json
+++ b/a/points/p1/layer4_questions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "question": "Explain what is meant by a validation test in computer science education.",
+    "answer": "A validation test checks that students have understood the material and are ready to progress."
+  },
+  {
+    "question": "State one advantage of practicing with past paper questions before an exam.",
+    "answer": "Past paper questions familiarize students with the exam style and improve confidence."
+  },
+  {
+    "question": "Give an example of a simple binary operation.",
+    "answer": "Adding two 1-bit binary numbers, e.g. 1 + 1 = 10."
+  }
+]


### PR DESCRIPTION
## Summary
- load questions and answers from new `layer4_questions.json`
- display Q/A pairs in `layer4.html`
- provide button to mark readiness that updates `a_theory_progress` via Supabase
- added accompanying `layer4.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873a47678748331b5a7ac2863e9796c