### PR TITLE
Handle string reached_layer

### DIFF
--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -48,7 +48,7 @@ export async function fetchProgressCounts() {
     const tData = await tRes.json();
     const lData = await lRes.json();
 
-    const passedPoints = tData.filter(r => r.reached_layer === 4).length;
+    const passedPoints = tData.filter(r => r.reached_layer === '4').length;
     let passedLevels = 0;
     if (platform === 'A_Level') {
       passedLevels = lData.length ? lData[0].reached_level : 0;

--- a/a/modules/theoryRenderer.js
+++ b/a/modules/theoryRenderer.js
@@ -44,8 +44,8 @@ export async function renderTheoryPoints() {
   points.forEach(point => {
     console.debug('[theoryRenderer] Rendering point', point.id);
     const entry = progressMap[point.id.toLowerCase()] || {};
-    const reached = entry.reached_layer || 0;
-    const layerStates = [1, 2, 3, 4].map(n => reached >= n ? "green" : "grey");
+    const reached = entry.reached_layer || '0';
+    const layerStates = [1, 2, 3, 4].map(n => Number(reached) >= n ? "green" : "grey");
 
     const box = document.createElement("div");
     box.className = "theory-box theory-clickable";

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -340,7 +340,7 @@
       .upsert({
         username: username,
         point_id: point_id.toLowerCase(),
-        reached_layer: 1
+        reached_layer: '1'
       }, { onConflict: ['username', 'point_id'] });
 
     if (error) {

--- a/a/points/p1/modules/supabase.js
+++ b/a/points/p1/modules/supabase.js
@@ -19,7 +19,7 @@ async function updateTheoryProgress(pointId, layer) {
     .upsert({
       username: username,
       point_id,
-      reached_layer: layer
+    reached_layer: String(layer)
     }, { onConflict: ['username', 'point_id'] });
 
   if (error) console.error("❌ Supabase Error:", error);  else console.log("✅ Supabase Progress Updated");}

--- a/a/points/p1/quiz.js
+++ b/a/points/p1/quiz.js
@@ -106,7 +106,7 @@ async function sendProgress() {
   await supabase.from(table).upsert({
     username: username,
     point_id: pointId,
-    reached_layer: 2
+    reached_layer: '2'
   }, { onConflict: ['username', 'point_id'] });
 }
 

--- a/a/points/p2/layer3.html
+++ b/a/points/p2/layer3.html
@@ -28,7 +28,7 @@ import { supabase } from '../../../supabaseClient.js';
     const { error } = await supabase
       .from(table)
       .upsert(
-        { username, point_id, reached_layer: 3 },
+        { username, point_id, reached_layer: '3' },
         { onConflict: ['username', 'point_id'] }
       );
     if (error) {

--- a/a/points/p2/quiz.js
+++ b/a/points/p2/quiz.js
@@ -104,7 +104,7 @@ function sendProgress() {
     body: JSON.stringify({
       username: username,
       point_id,
-      reached_layer: 2
+      reached_layer: '2'
     })
   });
 }

--- a/a/points/p3/layer3.html
+++ b/a/points/p3/layer3.html
@@ -28,7 +28,7 @@ import { supabase } from '../../../supabaseClient.js';
     const { error } = await supabase
       .from(table)
       .upsert(
-        { username, point_id, reached_layer: 3 },
+        { username, point_id, reached_layer: '3' },
         { onConflict: ['username', 'point_id'] }
       );
     if (error) {

--- a/a/points/p3/quiz.js
+++ b/a/points/p3/quiz.js
@@ -104,7 +104,7 @@ function sendProgress() {
     body: JSON.stringify({
       username: username,
       point_id,
-      reached_layer: 2
+      reached_layer: '2'
     })
   });
 }

--- a/a/points/p4/layer3.html
+++ b/a/points/p4/layer3.html
@@ -28,7 +28,7 @@ import { supabase } from '../../../supabaseClient.js';
     const { error } = await supabase
       .from(table)
       .upsert(
-        { username, point_id, reached_layer: 3 },
+        { username, point_id, reached_layer: '3' },
         { onConflict: ['username', 'point_id'] }
       );
     if (error) {

--- a/a/points/p4/quiz.js
+++ b/a/points/p4/quiz.js
@@ -104,7 +104,7 @@ function sendProgress() {
     body: JSON.stringify({
       username: username,
       point_id,
-      reached_layer: 2
+      reached_layer: '2'
     })
   });
 }

--- a/teacher/teacher.js
+++ b/teacher/teacher.js
@@ -149,7 +149,7 @@ async function renderTheory(data) {
       );
       if (found) {
         if (usesReachedLayer()) {
-          if (Number(found.reached_layer) >= i) checkbox.checked = true;
+          if (parseInt(found.reached_layer, 10) >= i) checkbox.checked = true;
         } else if (found[`layer${i}_done`]) {
           checkbox.checked = true;
         }
@@ -200,10 +200,12 @@ document.getElementById('save-progress').onclick = async () => {
   for (let point of theoryPoints) {
     console.debug('[teacher] Updating point', point);
     const pointInputs = document.querySelectorAll(`[data-point='${point}']`);
-    let reached_layer = 0;
+    let reached_layer = '0';
     pointInputs.forEach(input => {
       if (input.checked) {
-        reached_layer = Math.max(reached_layer, Number(input.dataset.layer));
+        if (parseInt(input.dataset.layer, 10) > parseInt(reached_layer, 10)) {
+          reached_layer = input.dataset.layer;
+        }
       }
     });
 


### PR DESCRIPTION
## Summary
- handle `reached_layer` as string in teacher dashboard
- adjust Supabase helper and renderers
- update point pages to send string values

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873a92c70f0833183cfbefb98af2f01