### PR TITLE
Display username in notes and exported PDF

### DIFF
--- a/a/points/p1/layer3.html
+++ b/a/points/p1/layer3.html
@@ -144,7 +144,7 @@
     </div>
 
     <section id="review-notes">
-      <h2>📝 Review My Notes</h2>
+      <h2 id="notes-title">📝 My Notes</h2>
       <ul id="notes-list"></ul>
       <button id="export-btn">Export My Notes as PDF</button>
     </section>

--- a/a/points/p1/layer3.js
+++ b/a/points/p1/layer3.js
@@ -9,9 +9,14 @@ const questionContainer = document.getElementById('questions-container');
 const notesList = document.getElementById('notes-list');
 const exportBtn = document.getElementById('export-btn');
 const layer4Btn = document.getElementById('layer4-btn');
+const notesTitle = document.getElementById('notes-title');
 
 let totalQuestions = 0;
 const savedNotes = new Set();
+
+if (username && notesTitle) {
+  notesTitle.textContent = `📝 ${username}'s Notes`;
+}
 
 if (studentName) {
   document.getElementById('student-name').textContent = '👤 ' + studentName;
@@ -149,8 +154,9 @@ exportBtn.addEventListener('click', async () => {
   if (error) return console.error('Fetch notes error', error);
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF();
-  doc.setFontSize(16);
-  doc.text('Layer 3 Reflection Notes', 10, 20);
+  doc.setFontSize(18);
+  const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
+  doc.text(pdfTitle, 10, 20);
   let y = 30;
   (data || []).forEach(row => {
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;


### PR DESCRIPTION
## Summary
- personalize notes section heading using username
- include username in exported PDF title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68743d518fdc83318ed4f3e42ad24534