### PR TITLE
Remove dynamic height calculations

### DIFF
--- a/a/points/p1/doc.html
+++ b/a/points/p1/doc.html
@@ -46,13 +46,6 @@
       <li><div class="example-box"><span class="example-icon">➗</span> Denary 142: 142 ÷ 2 repeatedly gives remainders 1 0 0 0 1 1 1 0 (read bottom to top: 10001110).</div></li>
     </ul>
   </div>
-  <script>
-    function sendHeight() {
-      const height = document.documentElement.scrollHeight;
-      window.parent.postMessage({ type: 'docHeight', height }, '*');
-    }
-    window.addEventListener('load', sendHeight);
-    window.addEventListener('resize', sendHeight);
-  </script>
+  
 </body>
 </html>

--- a/a/points/p1/layer1.html
+++ b/a/points/p1/layer1.html
@@ -92,7 +92,7 @@
     }
 
     #official-notes {
-      /* allow iframe to grow based on content */
+      height: 4750px;
     }
 
     .official-doc {
@@ -204,7 +204,7 @@
 
   <main id="content-area" style="display: none;">
     <div id="official-notes">
-      <iframe id="doc-frame" class="official-doc" scrolling="no"></iframe>
+      <iframe id="doc-frame" class="official-doc" scrolling="no" style="height: 4750px;"></iframe>
     </div>
   </main>
 
@@ -266,30 +266,9 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-
-            function adjustHeight(height) {
-              const scale = 1.1; // matches `.official-doc` scale
-              if (!height) {
-                try {
-                  const docEl = frame.contentDocument || frame.contentWindow.document;
-                  height = docEl.documentElement.scrollHeight;
-                } catch (_) {
-                  return; // cross-origin, wait for postMessage
-                }
-              }
-              const newHeight = Math.ceil(height * scale);
-              frame.style.height = newHeight + 'px';
-              document.getElementById('official-notes').style.height = newHeight + 'px';
-            }
-
-            frame.addEventListener('load', () => adjustHeight());
-            window.addEventListener('resize', () => adjustHeight());
-
-            window.addEventListener('message', (e) => {
-              if (e.data && e.data.type === 'docHeight') {
-                adjustHeight(e.data.height);
-              }
-            });
+            const height = 4750;
+            frame.style.height = height + 'px';
+            document.getElementById('official-notes').style.height = height + 'px';
           }
 
           if (videos.length > 0) {

--- a/a/points/p2/doc.html
+++ b/a/points/p2/doc.html
@@ -10,13 +10,6 @@
     <h1>Point Notes</h1>
     <p>This is a placeholder page for the full HTML notes. Replace this content with the actual notes as needed.</p>
   </main>
-  <script>
-    function sendHeight() {
-      const height = document.documentElement.scrollHeight;
-      window.parent.postMessage({ type: 'docHeight', height }, '*');
-    }
-    window.addEventListener('load', sendHeight);
-    window.addEventListener('resize', sendHeight);
-  </script>
+
 </body>
 </html>

--- a/a/points/p2/layer1.html
+++ b/a/points/p2/layer1.html
@@ -6,33 +6,10 @@
 </head>
 <body>
   <div class="header">Layer 1 - Theory</div>
-  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none;"></iframe>
+  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none; height: 4750px;"></iframe>
   <div style="text-align: center; margin: 20px;">
     <a href="layer2.html"><button>Next → Layer 2</button></a>
   </div>
-  <script>
-    const frame = document.getElementById('doc-frame');
 
-    function adjustHeight(height) {
-      if (!height) {
-        try {
-          const doc = frame.contentDocument || frame.contentWindow.document;
-          height = doc.documentElement.scrollHeight;
-        } catch (_) {
-          return; // cross-origin, wait for postMessage
-        }
-      }
-      frame.style.height = height + 'px';
-    }
-
-    frame.addEventListener('load', () => adjustHeight());
-    window.addEventListener('resize', () => adjustHeight());
-
-    window.addEventListener('message', (e) => {
-      if (e.data && e.data.type === 'docHeight') {
-        adjustHeight(e.data.height);
-      }
-    });
-  </script>
 </body>
 </html>

--- a/a/points/p3/doc.html
+++ b/a/points/p3/doc.html
@@ -10,13 +10,6 @@
     <h1>Point Notes</h1>
     <p>This is a placeholder page for the full HTML notes. Replace this content with the actual notes as needed.</p>
   </main>
-  <script>
-    function sendHeight() {
-      const height = document.documentElement.scrollHeight;
-      window.parent.postMessage({ type: 'docHeight', height }, '*');
-    }
-    window.addEventListener('load', sendHeight);
-    window.addEventListener('resize', sendHeight);
-  </script>
+
 </body>
 </html>

--- a/a/points/p3/layer1.html
+++ b/a/points/p3/layer1.html
@@ -6,33 +6,10 @@
 </head>
 <body>
   <div class="header">Layer 1 - Theory</div>
-  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none;"></iframe>
+  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none; height: 4750px;"></iframe>
   <div style="text-align: center; margin: 20px;">
     <a href="layer2.html"><button>Next → Layer 2</button></a>
   </div>
-  <script>
-    const frame = document.getElementById('doc-frame');
 
-    function adjustHeight(height) {
-      if (!height) {
-        try {
-          const doc = frame.contentDocument || frame.contentWindow.document;
-          height = doc.documentElement.scrollHeight;
-        } catch (_) {
-          return; // cross-origin, wait for postMessage
-        }
-      }
-      frame.style.height = height + 'px';
-    }
-
-    frame.addEventListener('load', () => adjustHeight());
-    window.addEventListener('resize', () => adjustHeight());
-
-    window.addEventListener('message', (e) => {
-      if (e.data && e.data.type === 'docHeight') {
-        adjustHeight(e.data.height);
-      }
-    });
-  </script>
 </body>
 </html>

--- a/a/points/p4/doc.html
+++ b/a/points/p4/doc.html
@@ -10,13 +10,6 @@
     <h1>Point Notes</h1>
     <p>This is a placeholder page for the full HTML notes. Replace this content with the actual notes as needed.</p>
   </main>
-  <script>
-    function sendHeight() {
-      const height = document.documentElement.scrollHeight;
-      window.parent.postMessage({ type: 'docHeight', height }, '*');
-    }
-    window.addEventListener('load', sendHeight);
-    window.addEventListener('resize', sendHeight);
-  </script>
+
 </body>
 </html>

--- a/a/points/p4/layer1.html
+++ b/a/points/p4/layer1.html
@@ -6,33 +6,10 @@
 </head>
 <body>
   <div class="header">Layer 1 - Theory</div>
-  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none;"></iframe>
+  <iframe id="doc-frame" src="doc.html" width="100%" scrolling="no" style="border:none; height: 4750px;"></iframe>
   <div style="text-align: center; margin: 20px;">
     <a href="layer2.html"><button>Next → Layer 2</button></a>
   </div>
-  <script>
-    const frame = document.getElementById('doc-frame');
 
-    function adjustHeight(height) {
-      if (!height) {
-        try {
-          const doc = frame.contentDocument || frame.contentWindow.document;
-          height = doc.documentElement.scrollHeight;
-        } catch (_) {
-          return; // cross-origin, wait for postMessage
-        }
-      }
-      frame.style.height = height + 'px';
-    }
-
-    frame.addEventListener('load', () => adjustHeight());
-    window.addEventListener('resize', () => adjustHeight());
-
-    window.addEventListener('message', (e) => {
-      if (e.data && e.data.type === 'docHeight') {
-        adjustHeight(e.data.height);
-      }
-    });
-  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- delete `sendHeight` script in each `doc.html`
- inline constant height for `doc-frame` iframes
- remove JS that adjusted iframe height dynamically
- set `official-notes` container to fixed height

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875867d90d083319f4dbc00f3a94530