### PR TITLE
Add dynamic Supabase table helper

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/13.1/layer4.js
+++ b/a/points/13.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/13.1/modules/feedback.js
+++ b/a/points/13.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/13.2/layer4.js
+++ b/a/points/13.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/13.2/modules/feedback.js
+++ b/a/points/13.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/13.3/layer4.js
+++ b/a/points/13.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/13.3/modules/feedback.js
+++ b/a/points/13.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/14.1/layer4.js
+++ b/a/points/14.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/14.1/modules/feedback.js
+++ b/a/points/14.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/14.2/layer4.js
+++ b/a/points/14.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/14.2/modules/feedback.js
+++ b/a/points/14.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/15.1/layer4.js
+++ b/a/points/15.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/15.1/modules/feedback.js
+++ b/a/points/15.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/15.2/layer4.js
+++ b/a/points/15.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/15.2/modules/feedback.js
+++ b/a/points/15.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/16.1/layer4.js
+++ b/a/points/16.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/16.1/modules/feedback.js
+++ b/a/points/16.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/16.2/layer4.js
+++ b/a/points/16.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/16.2/modules/feedback.js
+++ b/a/points/16.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/17/layer4.js
+++ b/a/points/17/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/17/modules/feedback.js
+++ b/a/points/17/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/18/layer4.js
+++ b/a/points/18/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/18/modules/feedback.js
+++ b/a/points/18/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/19.1/layer4.js
+++ b/a/points/19.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/19.1/modules/feedback.js
+++ b/a/points/19.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/19.2/layer4.js
+++ b/a/points/19.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/19.2/modules/feedback.js
+++ b/a/points/19.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/20.1/layer4.js
+++ b/a/points/20.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/20.1/modules/feedback.js
+++ b/a/points/20.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/a/points/20.2/layer4.js
+++ b/a/points/20.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/a/points/20.2/modules/feedback.js
+++ b/a/points/20.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/1.1/layer4.js
+++ b/as/points/1.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/1.1/modules/feedback.js
+++ b/as/points/1.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/1.2/layer4.js
+++ b/as/points/1.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/1.2/modules/feedback.js
+++ b/as/points/1.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/1.3/layer4.js
+++ b/as/points/1.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/1.3/modules/feedback.js
+++ b/as/points/1.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/2/layer4.js
+++ b/as/points/2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/2/modules/feedback.js
+++ b/as/points/2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/3.1/layer4.js
+++ b/as/points/3.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/3.1/modules/feedback.js
+++ b/as/points/3.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/3.2/layer4.js
+++ b/as/points/3.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/3.2/modules/feedback.js
+++ b/as/points/3.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/4.1/layer4.js
+++ b/as/points/4.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/4.1/modules/feedback.js
+++ b/as/points/4.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/4.2/layer4.js
+++ b/as/points/4.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/4.2/modules/feedback.js
+++ b/as/points/4.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/4.3/layer4.js
+++ b/as/points/4.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/4.3/modules/feedback.js
+++ b/as/points/4.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/5/layer4.js
+++ b/as/points/5/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/5/modules/feedback.js
+++ b/as/points/5/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/6/layer4.js
+++ b/as/points/6/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/6/modules/feedback.js
+++ b/as/points/6/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/7/layer4.js
+++ b/as/points/7/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/7/modules/feedback.js
+++ b/as/points/7/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/8.1/layer4.js
+++ b/as/points/8.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/8.1/modules/feedback.js
+++ b/as/points/8.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/8.2/layer4.js
+++ b/as/points/8.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/8.2/modules/feedback.js
+++ b/as/points/8.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/as/points/8.3/layer4.js
+++ b/as/points/8.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/as/points/8.3/modules/feedback.js
+++ b/as/points/8.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/1.1/layer4.js
+++ b/igcse/points/1.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/1.1/modules/feedback.js
+++ b/igcse/points/1.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/1.2/layer4.js
+++ b/igcse/points/1.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/1.2/modules/feedback.js
+++ b/igcse/points/1.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/1.3/layer4.js
+++ b/igcse/points/1.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/1.3/modules/feedback.js
+++ b/igcse/points/1.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/2.1/layer4.js
+++ b/igcse/points/2.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/2.1/modules/feedback.js
+++ b/igcse/points/2.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/2.2/layer4.js
+++ b/igcse/points/2.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/2.2/modules/feedback.js
+++ b/igcse/points/2.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/2.3/layer4.js
+++ b/igcse/points/2.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/2.3/modules/feedback.js
+++ b/igcse/points/2.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/3.1/layer4.js
+++ b/igcse/points/3.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/3.1/modules/feedback.js
+++ b/igcse/points/3.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/3.2/layer4.js
+++ b/igcse/points/3.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/3.2/modules/feedback.js
+++ b/igcse/points/3.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/3.3/layer4.js
+++ b/igcse/points/3.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/3.3/modules/feedback.js
+++ b/igcse/points/3.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/3.4/layer4.js
+++ b/igcse/points/3.4/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/3.4/modules/feedback.js
+++ b/igcse/points/3.4/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/4.1/layer4.js
+++ b/igcse/points/4.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/4.1/modules/feedback.js
+++ b/igcse/points/4.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/4.2/layer4.js
+++ b/igcse/points/4.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/4.2/modules/feedback.js
+++ b/igcse/points/4.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/5.1/layer4.js
+++ b/igcse/points/5.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/5.1/modules/feedback.js
+++ b/igcse/points/5.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/5.2/layer4.js
+++ b/igcse/points/5.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/5.2/modules/feedback.js
+++ b/igcse/points/5.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/5.3/layer4.js
+++ b/igcse/points/5.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/5.3/modules/feedback.js
+++ b/igcse/points/5.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/6.1/layer4.js
+++ b/igcse/points/6.1/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/6.1/modules/feedback.js
+++ b/igcse/points/6.1/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/6.2/layer4.js
+++ b/igcse/points/6.2/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/6.2/modules/feedback.js
+++ b/igcse/points/6.2/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -318,12 +318,17 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    const feedbackTable = {
+      A_Level: 'a_theory_feedback',
+      AS_Level: 'as_theory_feedback',
+      IGCSE: 'igcse_theory_feedback'
+    }[platform];
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;
     try {
       const { error } = await supabase
-        .from("a_theory_feedback")
+        .from(feedbackTable)
         .upsert([
           {
             username: username,

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const username = localStorage.getItem('username');
 const studentName = localStorage.getItem('student_name');
@@ -29,7 +29,7 @@ document.getElementById('point-title').textContent = pointId;
 async function loadSaved() {
   if (!username) return {};
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase());
@@ -120,7 +120,7 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -132,7 +132,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from('a_layer3').upsert({
+          await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -155,7 +155,7 @@ async function render() {
 
 exportBtn.addEventListener('click', async () => {
   const { data, error } = await supabase
-    .from('a_layer3')
+    .from(tableName('layer3'))
     .select('*')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())

--- a/igcse/points/6.3/layer4.js
+++ b/igcse/points/6.3/layer4.js
@@ -1,4 +1,4 @@
-import { supabase } from '../../../supabaseClient.js';
+import { supabase, tableName } from '../../../supabaseClient.js';
 
 const studentName = localStorage.getItem('student_name');
 const username = localStorage.getItem('username');
@@ -53,7 +53,7 @@ function renderQuestions(questions) {
 
 async function markReady() {
   const { data: existing } = await supabase
-    .from('a_theory_progress')
+    .from(tableName('theory_progress'))
     .select('reached_layer')
     .eq('username', username)
     .eq('point_id', pointId.toLowerCase())
@@ -61,7 +61,7 @@ async function markReady() {
   const score = v => v === 'R' ? 4 : (parseInt(v, 10) || 0);
   let error = null;
   if (score(existing?.reached_layer) < 4) {
-    ({ error } = await supabase.from('a_theory_progress').upsert({
+    ({ error } = await supabase.from(tableName('theory_progress')).upsert({
       username,
       point_id: pointId.toLowerCase(),
       reached_layer: 'R'

--- a/igcse/points/6.3/modules/feedback.js
+++ b/igcse/points/6.3/modules/feedback.js
@@ -15,7 +15,7 @@ const client = window.supabase;
     });
 
     // Insert into Supabase
-    const { error } = await client.from("a_theory_feedback").upsert([{
+    const { error } = await client.from(window.tableName('theory_feedback')).upsert([{
       username: username,
       point_id,
       feedback,

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -8,6 +8,19 @@ export const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdX
 console.log('[supabaseClient] Creating client with URL:', SUPABASE_URL);
 export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
 
+export function tableName(base) {
+  const platform = localStorage.getItem('platform');
+  const prefix = {
+    A_Level: 'a_',
+    AS_Level: 'as_',
+    IGCSE: 'igcse_'
+  }[platform] || 'a_';
+  return `${prefix}${base}`;
+}
+
+// expose helper for non-module scripts
+window.tableName = tableName;
+
 window.addEventListener('error', e => {
   console.error('[Global Error]', e.message, e.error);
 });

--- a/teacher/teacher.js
+++ b/teacher/teacher.js
@@ -1,5 +1,5 @@
 
-import { supabase } from '../supabaseClient.js';
+import { supabase, tableName } from '../supabaseClient.js';
 import { levels as levelDefs } from '../a/modules/levelRenderer.js';
 
 console.log('[teacher] teacher.js loaded');
@@ -319,7 +319,7 @@ if (addStudentForm) {
       if (error) throw error;
 
       if (platform === 'A_Level') {
-        await supabase.from('a_programming_progress').insert({
+        await supabase.from(tableName('programming_progress')).insert({
           username: username,
           reached_level: 0
         });


### PR DESCRIPTION
## Summary
- expose `tableName` helper from `supabaseClient.js`
- use `tableName()` across all point layers
- update teacher dashboard to use helper
- adapt feedback modules and layer1 pages for platform specific tables

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68776ecc761c833180dca4f996a37296