### PR TITLE
Ensure apikey headers included

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -6,7 +6,14 @@ export const SUPABASE_URL = "https://tsmzmuclrnyryuvanlxl.supabase.co";
 export const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
 
 console.log('[supabaseClient] Creating client with URL:', SUPABASE_URL);
-export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  global: {
+    headers: {
+      apikey: SUPABASE_KEY,
+      Authorization: `Bearer ${SUPABASE_KEY}`
+    }
+  }
+});
 
 export function tableName(base) {
   const platform = localStorage.getItem('platform');


### PR DESCRIPTION
## Summary
- include `apikey` and `Authorization` headers globally when creating the Supabase client

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68791fe92b2483319c243b9e6941d8e3