### PR TITLE
Unify AS platform progress storage

### DIFF
--- a/as/modules/supabase.js
+++ b/as/modules/supabase.js
@@ -47,7 +47,7 @@ export async function fetchProgressCounts() {
           Authorization: 'Bearer ' + SUPABASE_KEY
         }
       }),
-      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' ? 'reached_level' : 'level_done'}&username=eq.${encodeURIComponent(username)}`, {
+      fetch(`${base}/${levelTable}?select=reached_level&username=eq.${encodeURIComponent(username)}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
@@ -59,12 +59,7 @@ export async function fetchProgressCounts() {
     const lData = await lRes.json();
 
     const passedPoints = tData.filter(r => r.reached_layer === '4').length;
-    let passedLevels = 0;
-    if (platform === 'A_Level') {
-      passedLevels = lData.length ? lData[0].reached_level : 0;
-    } else {
-      passedLevels = lData.filter(r => r.level_done).length;
-    }
+    const passedLevels = lData.length ? lData[0].reached_level : 0;
     const result = { points: passedPoints, levels: passedLevels };
     console.log('[supabaseModule] Progress counts', result);
     return result;


### PR DESCRIPTION
## Summary
- AS platform should use `reached_level` like the other platforms
- simplify teacher dashboard programming progress logic

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687964e97908833195c1a442cc54429d