### PR TITLE
Fix syllabus badge position

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -542,8 +542,8 @@ footer {
 /* Syllabus Update Badge - Front Layer */
 .syllabus-update-badge {
   position: fixed;
-  top: 70px;
-  right: 10px;
+  top: 50px; /* moved 20px up */
+  right: 0px; /* moved 10px to the right */
   z-index: 1000; /* Ensures it appears above all other content */
   width: 250px;
   height: 250px;


### PR DESCRIPTION
## Summary
- tweak `.syllabus-update-badge` position

## Testing
- `npx htmlhint index.html` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68796e5ea46c8331bd616b81e9f0f54d