### PR TITLE
Fix doc iframe width

### DIFF
--- a/igcse/points/6.3/igcse-style.css
+++ b/igcse/points/6.3/igcse-style.css
@@ -5,7 +5,9 @@ body {
   line-height: 1.7;
 }
 .container {
-  max-width: 850px;
+  /* Stretch to the full width of the iframe so no empty space is left */
+  width: 100%;
+  max-width: none;
   margin: 2.5rem auto;
   background: #fff;
   border-radius: 14px;


### PR DESCRIPTION
## Summary
- make `doc.html` container width full width so it doesn't leave space in iframe

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688357112ebc8331a3bae99cbca511aa