### PR TITLE
Handle multi-blank answers in IGCSE quiz

### DIFF
--- a/igcse/points/1.1/quiz.js
+++ b/igcse/points/1.1/quiz.js
@@ -32,7 +32,13 @@ function startQuiz(questions) {
         html += `<label><input type="radio" name="q${i}" value="${opt}">${opt}</label><br>`;
       });
     } else if (q.type === "fill_blank") {
-      html += `<input type="text" name="q${i}" placeholder="Your answer">`;
+      if (Array.isArray(q.answer)) {
+        q.answer.forEach((_, j) => {
+          html += `<input type="text" name="q${i}_${j}" placeholder="Answer ${j + 1}">`;
+        });
+      } else {
+        html += `<input type="text" name="q${i}" placeholder="Your answer">`;
+      }
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       const values = shuffle(Object.values(q.pairs));
@@ -62,8 +68,17 @@ function checkAnswers(questions) {
       const val = sel ? sel.value : "";
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
-      const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      if (Array.isArray(q.answer)) {
+        const vals = q.answer.map((_, j) =>
+          document.querySelector(`input[name="q${i}_${j}"]`).value.trim()
+        );
+        isCorrect =
+          vals.length === q.answer.length &&
+          vals.every((v, idx) => v.toLowerCase() === q.answer[idx].toLowerCase());
+      } else {
+        const val = document.querySelector(`input[name="q${i}"]`).value.trim();
+        isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      }
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/1.1/quiz.json
+++ b/igcse/points/1.1/quiz.json
@@ -109,7 +109,10 @@
       "section": "1.1e",
       "type": "fill_blank",
       "question": "A _____ _____ shifts bits left or right and fills emptied positions with zeros.",
-      "answer": "logical shift"
+      "answer": [
+        "logical",
+        "shift"
+      ]
     },
     {
       "section": "1.1e",


### PR DESCRIPTION
## Summary
- Render one text box per expected blank when a quiz question's answer list contains multiple items
- Validate multi-blank responses by comparing each field case-insensitively in order
- Store multi-word answers as arrays in quiz data to support multi-blank rendering

## Testing
- `node --check igcse/points/1.1/quiz.js && echo SyntaxOK`
- `node -e "const fs=require('fs');JSON.parse(fs.readFileSync('igcse/points/1.1/quiz.json','utf8'));console.log('JSON OK')"`


------
https://chatgpt.com/codex/tasks/task_e_689fc9be219c8331959148f1a7765406