### PR TITLE
feat: allow minor typos in fill-in-the-blank answers

### DIFF
--- a/a/points/13.1/quiz.js
+++ b/a/points/13.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/13.2/quiz.js
+++ b/a/points/13.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/13.3/quiz.js
+++ b/a/points/13.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/14.1/quiz.js
+++ b/a/points/14.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/14.2/quiz.js
+++ b/a/points/14.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/15.1/quiz.js
+++ b/a/points/15.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/15.2/quiz.js
+++ b/a/points/15.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/16.1/quiz.js
+++ b/a/points/16.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/16.2/quiz.js
+++ b/a/points/16.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/17/quiz.js
+++ b/a/points/17/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/18/quiz.js
+++ b/a/points/18/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/19.1/quiz.js
+++ b/a/points/19.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/19.2/quiz.js
+++ b/a/points/19.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/20.1/quiz.js
+++ b/a/points/20.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/a/points/20.2/quiz.js
+++ b/a/points/20.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/1.1/quiz.js
+++ b/as/points/1.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/1.2/quiz.js
+++ b/as/points/1.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/1.3/quiz.js
+++ b/as/points/1.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/2/quiz.js
+++ b/as/points/2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/3.1/quiz.js
+++ b/as/points/3.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/3.2/quiz.js
+++ b/as/points/3.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/4.1/quiz.js
+++ b/as/points/4.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/4.2/quiz.js
+++ b/as/points/4.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/4.3/quiz.js
+++ b/as/points/4.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/5/quiz.js
+++ b/as/points/5/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/6/quiz.js
+++ b/as/points/6/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/7/quiz.js
+++ b/as/points/7/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/8.1/quiz.js
+++ b/as/points/8.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/8.2/quiz.js
+++ b/as/points/8.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/as/points/8.3/quiz.js
+++ b/as/points/8.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/1.1/quiz.js
+++ b/igcse/points/1.1/quiz.js
@@ -56,6 +56,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -74,10 +94,10 @@ function checkAnswers(questions) {
         );
         isCorrect =
           vals.length === q.answer.length &&
-          vals.every((v, idx) => v.toLowerCase() === q.answer[idx].toLowerCase());
+          vals.every((v, idx) => withinOneEdit(v, q.answer[idx]));
       } else {
         const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-        isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+        isCorrect = withinOneEdit(val, q.answer);
       }
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);

--- a/igcse/points/1.2/quiz.js
+++ b/igcse/points/1.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/1.3/quiz.js
+++ b/igcse/points/1.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/2.1/quiz.js
+++ b/igcse/points/2.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/2.2/quiz.js
+++ b/igcse/points/2.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/2.3/quiz.js
+++ b/igcse/points/2.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/3.1/quiz.js
+++ b/igcse/points/3.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/3.2/quiz.js
+++ b/igcse/points/3.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/3.3/quiz.js
+++ b/igcse/points/3.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/3.4/quiz.js
+++ b/igcse/points/3.4/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/4.1/quiz.js
+++ b/igcse/points/4.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/4.2/quiz.js
+++ b/igcse/points/4.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/5.1/quiz.js
+++ b/igcse/points/5.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/5.2/quiz.js
+++ b/igcse/points/5.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/5.3/quiz.js
+++ b/igcse/points/5.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/6.1/quiz.js
+++ b/igcse/points/6.1/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/6.2/quiz.js
+++ b/igcse/points/6.2/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>

--- a/igcse/points/6.3/quiz.js
+++ b/igcse/points/6.3/quiz.js
@@ -50,6 +50,26 @@ function startQuiz(questions) {
   container.appendChild(submit);
 }
 
+function withinOneEdit(a, b) {
+  a = a.toLowerCase();
+  b = b.toLowerCase();
+  if (a === b) return true;
+  const lenA = a.length, lenB = b.length;
+  if (Math.abs(lenA - lenB) > 1) return false;
+  let i = 0, j = 0, edits = 0;
+  while (i < lenA && j < lenB) {
+    if (a[i] === b[j]) { i++; j++; }
+    else {
+      if (++edits > 1) return false;
+      if (lenA > lenB) i++;
+      else if (lenB > lenA) j++;
+      else { i++; j++; }
+    }
+  }
+  if (i < lenA || j < lenB) edits++;
+  return edits <= 1;
+}
+
 function checkAnswers(questions) {
   let correct = 0;
   const result = document.getElementById("quiz-result");
@@ -63,7 +83,7 @@ function checkAnswers(questions) {
       isCorrect = val === q.answer;
     } else if (q.type === "fill_blank") {
       const val = document.querySelector(`input[name="q${i}"]`).value.trim();
-      isCorrect = val.toLowerCase() === q.answer.toLowerCase();
+      isCorrect = withinOneEdit(val, q.answer);
     } else if (q.type === "match") {
       const pairs = Object.entries(q.pairs);
       isCorrect = pairs.every(([key, correct], j) =>


### PR DESCRIPTION
## Summary
- add `withinOneEdit` helper to allow answers differing by a single insertion, deletion or substitution
- use the helper for fill-in-the-blank checks across all quizzes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a056b3ee5c8331a7c5f86babebd21f