### PR TITLE
Send resize info from point docs and remove static height placeholders

### DIFF
--- a/igcse/points/1.1/doc.html
+++ b/igcse/points/1.1/doc.html
@@ -220,5 +220,11 @@
 </div>
 
   <script src="popup-script.js"></script>
+  <script>
+    window.addEventListener('load', function() {
+      var height = document.body.scrollHeight;
+      window.parent.postMessage({type: 'resize', height: height}, '*');
+    });
+  </script>
 </body>
 </html>

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -254,9 +254,6 @@
           if (doc) {
             const frame = document.getElementById("doc-frame");
             frame.src = doc.url;
-            const height = 4750;
-            
-            
           }
 
           if (videos.length > 0) {


### PR DESCRIPTION
## Summary
- post the scroll height of `igcse/points/1.1/doc.html` to its parent so embedded iframe can resize correctly
- remove unused static height constants from all IGCSE point `layer1.html` pages so docs display fully

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a05564487c83319afda6f5edbdd1b0