### PR TITLE
Fix IGCSE layer1 doc height auto-resize

### DIFF
--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -253,6 +253,9 @@
 
           if (doc) {
             const frame = document.getElementById("doc-frame");
+            frame.addEventListener("load", function() {
+              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+            });
             frame.src = doc.url;
           }
 


### PR DESCRIPTION
## Summary
- Ensure each IGCSE layer1 page resizes its embedded doc iframe after load so full content displays

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fc8dfb38833184326efac4eda41d