### PR TITLE
Add page break handling to Layer 3 PDF exports

### DIFF
--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -166,7 +166,9 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(6);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -166,7 +166,9 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(4.1);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -166,12 +166,22 @@ exportBtn.addEventListener('click', async () => {
   doc.setFontSize(18);
   const pdfTitle = username ? `${username}'s Layer 3 Reflection Notes` : 'Layer 3 Reflection Notes';
   doc.text(pdfTitle, 10, 20);
-  let y = 30;
+  const margin = 20;
+  const pageHeight = doc.internal.pageSize.getHeight();
+  let y = margin + 10;
   (data || []).forEach(row => {
+    if (y > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     const text = `Q${row.question_number} (${new Date(row.corrected_at || row.submitted_at).toLocaleString()})`;
     doc.text(text, 10, y);
     y += 6;
     const split = doc.splitTextToSize(row.correction_note || '', 180);
+    if (y + split.length * 6 > pageHeight - margin) {
+      doc.addPage();
+      y = margin;
+    }
     doc.text(split, 10, y);
     y += split.length * 6 + 4;
   });


### PR DESCRIPTION
## Summary
- track vertical position in Layer 3 export routines
- add pages when content exceeds available height to prevent clipping

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a26c8d69c0833181ba96b2ce845c65