### PR TITLE
Validate platform before saving and surface layer3 upsert errors

### DIFF
--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -122,13 +122,18 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save answer error', error);
+            alert('Failed to save answer.');
+            return;
+          }
           localStorage.setItem(progressKey, q.question_number);
           if (q.question_number >= totalQuestions) {
             localStorage.removeItem(progressKey);
@@ -138,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          await supabase.from(tableName('layer3')).upsert({
+          const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -146,6 +151,11 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
+          if (error || !data?.length) {
+            console.error('Save note error', error);
+            alert('Failed to save note.');
+            return;
+          }
           addNoteToReview(q.question_number, note, new Date());
           savedNotes.add(q.question_number);
           checkAllNotesSaved();

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -17,11 +17,16 @@ export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
 
 export function tableName(base) {
   const platform = localStorage.getItem('platform');
-  const prefix = {
+  const prefixMap = {
     A_Level: 'a_',
     AS_Level: 'as_',
     IGCSE: 'igcse_'
-  }[platform] || 'a_';
+  };
+  const prefix = prefixMap[platform];
+  if (!prefix) {
+    alert('Unable to determine platform. Please select a platform before saving.');
+    throw new Error('Unknown platform: ' + platform);
+  }
   return `${prefix}${base}`;
 }
 


### PR DESCRIPTION
## Summary
- Ensure `tableName` aborts when no valid platform is found instead of defaulting to `a_`
- Capture `upsert` results in all `layer3.js` save handlers and surface errors before alerting success

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a270c4b75483319aa4937ec042b77a