### PR TITLE
Add divider between Layer 4 question and answer columns

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -500,6 +500,19 @@ body {
   line-height: 18px;
 }
 
+/* Layer 4 question/answer column separation */
+.qa-row {
+  display: flex;
+}
+
+.qa-question {
+  border-right: 1px solid #e0e0e0;
+}
+
+.qa-answer {
+  background-color: #f9f9f9;
+}
+
 /* Navigation buttons shared across layers */
 .nav-btn {
   padding: 10px 20px;

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -500,6 +500,19 @@ body {
   line-height: 18px;
 }
 
+/* Layer 4 question/answer column separation */
+.qa-row {
+  display: flex;
+}
+
+.qa-question {
+  border-right: 1px solid #e0e0e0;
+}
+
+.qa-answer {
+  background-color: #f9f9f9;
+}
+
 /* Navigation buttons shared across layers */
 .nav-btn {
   padding: 10px 20px;

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -500,6 +500,19 @@ body {
   line-height: 18px;
 }
 
+/* Layer 4 question/answer column separation */
+.qa-row {
+  display: flex;
+}
+
+.qa-question {
+  border-right: 1px solid #e0e0e0;
+}
+
+.qa-answer {
+  background-color: #f9f9f9;
+}
+
 /* Navigation buttons shared across layers */
 .nav-btn {
   padding: 10px 20px;


### PR DESCRIPTION
## Summary
- Add subtle border and background styling to separate question and answer columns in Layer 4 pages
- Applies across A-level, AS-level, and IGCSE dashboards

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3595daf9483318539030be831eb89