### PR TITLE
Revert homepage links, keep SEO landing pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,17 +42,6 @@
       </div>
     </section>
 
-    
-    <!-- Links to key Cambridge Computer Science landing pages -->
-    <section aria-labelledby="igcse-as-a-links">
-      <h2 id="igcse-as-a-links">Cambridge IGCSE, AS Level, and A Level Computer Science resources</h2>
-      <ul>
-        <li><a href="/igcse/computer-science-0478/">Cambridge IGCSE Computer Science 0478 overview</a></li>
-        <li><a href="/as-level/computer-science-9618/">Cambridge International AS Level Computer Science 9618 overview</a></li>
-        <li><a href="/a-level/computer-science-9618/">Cambridge International A Level Computer Science 9618 overview</a></li>
-      </ul>
-    </section>
-
 <section class="row double-column">
   <div class="left-column path-frame">
     <h2 class="section-title">Choose Your Cambridge Path: The Full Journey</h2>


### PR DESCRIPTION
## Summary
- remove homepage block linking directly to IGCSE, AS, and A Level resources to revert visual changes
- verify sitemap and breadcrumb structured data remain intact for landing pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a43a4f2f28833195fbb2922e6a5a37