### PR TITLE
fix(seo): remove Course JSON-LD and add visible breadcrumbs on 0478 and 9618 pages

### DIFF
--- a/a-level/computer-science-9618/index.html
+++ b/a-level/computer-science-9618/index.html
@@ -19,31 +19,18 @@
     a {text-decoration: underline;}
     .card {border: 1px solid #ddd; padding: 12px; border-radius: 6px; margin-top: 12px;}
   </style>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Course",
-    "name": "Cambridge International A Level Computer Science 9618",
-    "description": "Syllabus-aligned preparation materials and instruction for the A Level 9618 qualification.",
-    "provider": {
-      "@type": "Organization",
-      "name": "hamdeni-cs.tn",
-      "url": "https://hamdeni-cs.tn"
-    }
-  }
-  </script>
 </head>
 <body>
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/a-level/">A Level</a></li>
+    <li aria-current="page">Computer Science 9618</li>
+  </ol>
+</nav>
 <header>
   <h1>Cambridge International A Level Computer Science 9618</h1>
   <p>This page provides curriculum-aligned materials for Cambridge International A Level Computer Science 9618, including a brief syllabus overview, structured notes, past papers, mark schemes, and study guidance.</p>
 </header>
-<nav aria-label="Breadcrumb">
-  <ol>
-    <li><a href="/a/">A Level</a></li>
-    <li aria-current="page">Computer Science 9618</li>
-  </ol>
-</nav>
 <main>
   <section id="syllabus-overview" class="card">
     <h2>Syllabus overview</h2>
@@ -96,7 +83,7 @@
  "@context": "https://schema.org",
  "@type": "BreadcrumbList",
  "itemListElement": [
-  {"@type":"ListItem","position":1,"name":"A Level","item":"https://hamdeni-cs.tn/a/"},
+  {"@type":"ListItem","position":1,"name":"A Level","item":"https://hamdeni-cs.tn/a-level/"},
   {"@type":"ListItem","position":2,"name":"Computer Science 9618","item":"https://hamdeni-cs.tn/a-level/computer-science-9618/"}
 ]
 }

--- a/as-level/computer-science-9618/index.html
+++ b/as-level/computer-science-9618/index.html
@@ -19,31 +19,18 @@
     a {text-decoration: underline;}
     .card {border: 1px solid #ddd; padding: 12px; border-radius: 6px; margin-top: 12px;}
   </style>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Course",
-    "name": "Cambridge International AS Level Computer Science 9618",
-    "description": "Syllabus-aligned preparation materials and instruction for the AS Level 9618 qualification.",
-    "provider": {
-      "@type": "Organization",
-      "name": "hamdeni-cs.tn",
-      "url": "https://hamdeni-cs.tn"
-    }
-  }
-  </script>
 </head>
 <body>
+<nav aria-label="Breadcrumb">
+  <ol>
+    <li><a href="/as-level/">AS Level</a></li>
+    <li aria-current="page">Computer Science 9618</li>
+  </ol>
+</nav>
 <header>
   <h1>Cambridge International AS Level Computer Science 9618</h1>
   <p>This page provides curriculum-aligned materials for Cambridge International AS Level Computer Science 9618, including a brief syllabus overview, structured notes, past papers, mark schemes, and study guidance.</p>
 </header>
-<nav aria-label="Breadcrumb">
-  <ol>
-    <li><a href="/as/">AS Level</a></li>
-    <li aria-current="page">Computer Science 9618</li>
-  </ol>
-</nav>
 <main>
   <section id="syllabus-overview" class="card">
     <h2>Syllabus overview</h2>
@@ -96,7 +83,7 @@
  "@context": "https://schema.org",
  "@type": "BreadcrumbList",
  "itemListElement": [
-  {"@type":"ListItem","position":1,"name":"AS Level","item":"https://hamdeni-cs.tn/as/"},
+  {"@type":"ListItem","position":1,"name":"AS Level","item":"https://hamdeni-cs.tn/as-level/"},
   {"@type":"ListItem","position":2,"name":"Computer Science 9618","item":"https://hamdeni-cs.tn/as-level/computer-science-9618/"}
 ]
 }

--- a/igcse/computer-science-0478/index.html
+++ b/igcse/computer-science-0478/index.html
@@ -19,31 +19,18 @@
     a {text-decoration: underline;}
     .card {border: 1px solid #ddd; padding: 12px; border-radius: 6px; margin-top: 12px;}
   </style>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "Course",
-    "name": "Cambridge IGCSE Computer Science 0478",
-    "description": "Syllabus-aligned preparation materials and instruction for the 0478 qualification.",
-    "provider": {
-      "@type": "Organization",
-      "name": "hamdeni-cs.tn",
-      "url": "https://hamdeni-cs.tn"
-    }
-  }
-  </script>
 </head>
 <body>
-<header>
-  <h1>Cambridge IGCSE Computer Science 0478</h1>
-  <p>This page provides curriculum-aligned materials for Cambridge IGCSE Computer Science 0478, including a brief syllabus overview, structured notes, past papers, mark schemes, and study guidance.</p>
-</header>
 <nav aria-label="Breadcrumb">
   <ol>
     <li><a href="/igcse/">IGCSE</a></li>
     <li aria-current="page">Computer Science 0478</li>
   </ol>
 </nav>
+<header>
+  <h1>Cambridge IGCSE Computer Science 0478</h1>
+  <p>This page provides curriculum-aligned materials for Cambridge IGCSE Computer Science 0478, including a brief syllabus overview, structured notes, past papers, mark schemes, and study guidance.</p>
+</header>
 <main>
   <section id="syllabus-overview" class="card">
     <h2>Syllabus overview</h2>


### PR DESCRIPTION
## Summary
- remove Course JSON-LD blocks from IGCSE 0478 and AS/A Level 9618 pages
- add visible breadcrumb navigation before page headings and update breadcrumb URLs

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a444b097ec833190017aad76bf9906