### PR TITLE
fix: canonicalize IGCSE dashboard links

### DIFF
--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Computer Science Journey</title>
   <link rel="stylesheet" href="./dashboard.css"/>
+  <link rel="canonical" href="https://hamdeni-cs.tn/igcse/computer-science-0478/"/>
 </head>
 <body>
 

--- a/igcse/levels/level1.html
+++ b/igcse/levels/level1.html
@@ -43,7 +43,7 @@
 <body>
   <header class="level-header">
     <div class="header-left">
-      <a href="../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../images/maarifLOGO.png" alt="Maarif Logo" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/1.1/layer2.html
+++ b/igcse/points/1.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.1/layer3.html
+++ b/igcse/points/1.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.1/layer4.html
+++ b/igcse/points/1.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/1.2/layer2.html
+++ b/igcse/points/1.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.2/layer3.html
+++ b/igcse/points/1.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.2/layer4.html
+++ b/igcse/points/1.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/1.3/layer2.html
+++ b/igcse/points/1.3/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.3/layer3.html
+++ b/igcse/points/1.3/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/1.3/layer4.html
+++ b/igcse/points/1.3/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/2.1/layer2.html
+++ b/igcse/points/2.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.1/layer3.html
+++ b/igcse/points/2.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.1/layer4.html
+++ b/igcse/points/2.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/2.2/layer2.html
+++ b/igcse/points/2.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.2/layer3.html
+++ b/igcse/points/2.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.2/layer4.html
+++ b/igcse/points/2.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/2.3/layer2.html
+++ b/igcse/points/2.3/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.3/layer3.html
+++ b/igcse/points/2.3/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/2.3/layer4.html
+++ b/igcse/points/2.3/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/3.1/layer2.html
+++ b/igcse/points/3.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.1/layer3.html
+++ b/igcse/points/3.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.1/layer4.html
+++ b/igcse/points/3.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/3.2/layer2.html
+++ b/igcse/points/3.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.2/layer3.html
+++ b/igcse/points/3.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.2/layer4.html
+++ b/igcse/points/3.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/3.3/layer2.html
+++ b/igcse/points/3.3/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.3/layer3.html
+++ b/igcse/points/3.3/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.3/layer4.html
+++ b/igcse/points/3.3/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/3.4/layer2.html
+++ b/igcse/points/3.4/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.4/layer3.html
+++ b/igcse/points/3.4/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/3.4/layer4.html
+++ b/igcse/points/3.4/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/4.1/layer2.html
+++ b/igcse/points/4.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.1/layer3.html
+++ b/igcse/points/4.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.1/layer4.html
+++ b/igcse/points/4.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/4.2/layer2.html
+++ b/igcse/points/4.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.2/layer3.html
+++ b/igcse/points/4.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/4.2/layer4.html
+++ b/igcse/points/4.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/5.1/layer2.html
+++ b/igcse/points/5.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.1/layer3.html
+++ b/igcse/points/5.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.1/layer4.html
+++ b/igcse/points/5.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/5.2/layer2.html
+++ b/igcse/points/5.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.2/layer3.html
+++ b/igcse/points/5.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.2/layer4.html
+++ b/igcse/points/5.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/5.3/layer2.html
+++ b/igcse/points/5.3/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.3/layer3.html
+++ b/igcse/points/5.3/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/5.3/layer4.html
+++ b/igcse/points/5.3/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/6.1/layer2.html
+++ b/igcse/points/6.1/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.1/layer3.html
+++ b/igcse/points/6.1/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.1/layer4.html
+++ b/igcse/points/6.1/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/6.2/layer2.html
+++ b/igcse/points/6.2/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.2/layer3.html
+++ b/igcse/points/6.2/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.2/layer4.html
+++ b/igcse/points/6.2/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -188,7 +188,7 @@
   <header>
 
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" id="maarif-logo" />
       </a>
     </div>

--- a/igcse/points/6.3/layer2.html
+++ b/igcse/points/6.3/layer2.html
@@ -189,7 +189,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.3/layer3.html
+++ b/igcse/points/6.3/layer3.html
@@ -140,7 +140,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/igcse/points/6.3/layer4.html
+++ b/igcse/points/6.3/layer4.html
@@ -99,7 +99,7 @@
 <body>
   <header>
     <div class="header-left">
-      <a href="../../dashboard.html">
+      <a href="/igcse/computer-science-0478/">
         <img src="../../../images/maarifLOGO.png" class="logo" />
       </a>
     </div>

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
   <div class="left-column path-frame">
     <h2 class="section-title">Choose Your Cambridge Path: The Full Journey</h2>
     <div class="path-buttons">
-      <a href="igcse/dashboard.html" class="ripple-button" data-label="IGCSE">
+      <a href="igcse/computer-science-0478/" class="ripple-button" data-label="IGCSE">
         <img src="images/igbutton.png" alt="IGCSE" />
       </a>
       <a href="as/dashboard.html" class="ripple-button" data-label="AS Level">


### PR DESCRIPTION
## Summary
- add canonical link tag for IGCSE dashboard
- point IGCSE links to new computer-science-0478 landing page

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a448fad85c8331be8248e5499f6ab7