### PR TITLE
Switch IGCSE primary URL to dashboard

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,3 +1,3 @@
 
-/igcse/dashboard.html /igcse/computer-science-0478/ 301
+/igcse/computer-science-0478/ /igcse/dashboard.html 301
 

--- a/igcse/computer-science-0478/index.html
+++ b/igcse/computer-science-0478/index.html
@@ -5,10 +5,10 @@
   <title>Cambridge IGCSE Computer Science 0478 - Notes, Past Papers, Mark Schemes</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="Cambridge IGCSE Computer Science 0478 resources - syllabus overview, structured notes by topic, past papers, mark schemes, and study guidance.">
-  <link rel="canonical" href="https://hamdeni-cs.tn/igcse/computer-science-0478/">
+  <link rel="canonical" href="https://hamdeni-cs.tn/igcse/dashboard.html">
   <meta property="og:title" content="Cambridge IGCSE Computer Science 0478 - Notes, Past Papers, Mark Schemes">
   <meta property="og:description" content="Syllabus-aligned notes, past papers, mark schemes, and study guidance for 0478.">
-  <meta property="og:url" content="https://hamdeni-cs.tn/igcse/computer-science-0478/">
+  <meta property="og:url" content="https://hamdeni-cs.tn/igcse/dashboard.html">
   <meta property="og:type" content="website">
   <style>
     body {font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; line-height: 1.6; margin: 0; padding: 0; color: #111;}
@@ -84,7 +84,7 @@
  "@type": "BreadcrumbList",
  "itemListElement": [
   {"@type":"ListItem","position":1,"name":"IGCSE","item":"https://hamdeni-cs.tn/igcse/"},
-  {"@type":"ListItem","position":2,"name":"Computer Science 0478","item":"https://hamdeni-cs.tn/igcse/computer-science-0478/"}
+  {"@type":"ListItem","position":2,"name":"Computer Science 0478","item":"https://hamdeni-cs.tn/igcse/dashboard.html"}
  ]
 }
 </script>

--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -3,9 +3,21 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-  <title>Computer Science Journey</title>
+  <title>Cambridge IGCSE Computer Science 0478 | hamdeni-cs.tn</title>
+  <meta name="description" content="IGCSE Computer Science 0478 resources on hamdeni-cs.tn.">
   <link rel="stylesheet" href="./dashboard.css"/>
-  <link rel="canonical" href="https://hamdeni-cs.tn/igcse/computer-science-0478/"/>
+  <link rel="canonical" href="https://hamdeni-cs.tn/igcse/dashboard.html">
+  <meta property="og:url" content="https://hamdeni-cs.tn/igcse/dashboard.html">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {"@type":"ListItem","position":1,"name":"IGCSE","item":"https://hamdeni-cs.tn/igcse/"},
+      {"@type":"ListItem","position":2,"name":"Computer Science 0478","item":"https://hamdeni-cs.tn/igcse/dashboard.html"}
+    ]
+  }
+  </script>
 </head>
 <body>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -4,7 +4,7 @@
     <loc>https://hamdeni-cs.tn/</loc>
   </url>
   <url>
-    <loc>https://hamdeni-cs.tn/igcse/computer-science-0478/</loc>
+    <loc>https://hamdeni-cs.tn/igcse/dashboard.html</loc>
   </url>
   <url>
     <loc>https://hamdeni-cs.tn/as-level/computer-science-9618/</loc>


### PR DESCRIPTION
## Summary
- restore `igcse/dashboard.html` with self canonical and SEO head tags
- redirect `/igcse/computer-science-0478/` to `/igcse/dashboard.html`
- update sitemap and internal references to new IGCSE dashboard URL

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d94c587c83318b77eba3d9e044cd