### PR TITLE
Align layer1 buttons and inline help text

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -92,9 +92,23 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
     }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
+    }
+
 
     .highlight-button {
       background-color: #007bff;
@@ -217,15 +231,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +401,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -92,8 +92,21 @@
     }
 
     .actions {
-      text-align: center;
+      display: flex;
+      justify-content: center;
+      gap: 15px;
       margin-top: 30px;
+    }
+
+    .help-wrapper {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+    }
+
+    #help-section {
+      display: none;
+      margin-top: 10px;
     }
 
     .highlight-button {
@@ -217,15 +230,16 @@
   <div class="action-card">
       <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
-    <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+    <div class="help-wrapper">
+      <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
+      <div id="help-section">
+        <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
+        <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
+      </div>
+    </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
     </div>
-
-  <div id="help-section">
-    <textarea id="unclear" rows="4" cols="60" placeholder="Describe what you need help with..."></textarea><br />
-    <button class="highlight-button" onclick="submitHelp()">Submit Help Request</button>
-  </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
@@ -386,7 +400,8 @@
   window.markConfused = markConfused;
 
   function showHelp() {
-    document.getElementById("help-section").style.display = "block";
+    const section = document.getElementById("help-section");
+    section.style.display = section.style.display === "block" ? "none" : "block";
   }
   window.showHelp = showHelp;
 


### PR DESCRIPTION
## Summary
- Lay out layer1 action buttons in a single horizontal row using flexbox
- Embed help textarea inside the button frame so it appears directly below “Need help”
- Toggle help section visibility with updated `showHelp`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ec369c4483319a99b803e5e5ab4f