### PR TITLE
Add divider between question and answer columns

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -78,6 +78,23 @@ body {
   max-width: 260px;
   height: auto;
 }
+
+/* Modern divider between question and answer columns */
+.qa-heading div:first-child,
+.qa-question {
+  position: relative;
+}
+
+.qa-heading div:first-child::after,
+.qa-question::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.2), rgba(0,0,0,0));
+}
 .footer-image, .certificate-image {
   display: block;
   margin: 30px auto 0;

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -500,6 +500,23 @@ body {
   line-height: 18px;
 }
 
+/* Modern divider between question and answer columns */
+.qa-heading div:first-child,
+.qa-question {
+  position: relative;
+}
+
+.qa-heading div:first-child::after,
+.qa-question::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.2), rgba(0,0,0,0));
+}
+
 /* Navigation buttons shared across layers */
 .nav-btn {
   padding: 10px 20px;

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -78,6 +78,23 @@ body {
   max-width: 260px;
   height: auto;
 }
+
+/* Modern divider between question and answer columns */
+.qa-heading div:first-child,
+.qa-question {
+  position: relative;
+}
+
+.qa-heading div:first-child::after,
+.qa-question::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 2px;
+  height: 100%;
+  background: linear-gradient(to bottom, rgba(0,0,0,0), rgba(0,0,0,0.2), rgba(0,0,0,0));
+}
 .footer-image, .certificate-image {
   display: block;
   margin: 30px auto 0;


### PR DESCRIPTION
## Summary
- Add modern gradient divider line between question and answer columns across all dashboard styles.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5eb4ba97c833181408afebb99ca0b