### PR TITLE
Remove outer action container and extra separator

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -177,16 +177,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -227,9 +217,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -240,7 +228,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -176,16 +176,6 @@
       color: #333;
       font-size: 0.95em;
     }
-      .action-card {
-      max-width: 600px;
-      margin: 40px auto;
-      padding: 20px;
-      border-radius: 12px;
-      border: 2px solid transparent;
-      background: linear-gradient(#ffffff, #ffffff) padding-box,
-                  linear-gradient(135deg, #003366, #00bfff) border-box;
-      box-shadow: 0 4px 12px rgba(0,0,0,0.1);
-    }
 
     .section-divider {
       height: 4px;
@@ -226,9 +216,7 @@
   <main id="content-area" style="display: none;">
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
-
-  <div class="action-card">
-      <div class="actions">
+  <div class="actions">
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>
@@ -239,7 +227,6 @@
     </div>
     <button class="highlight-button btn-confused" onclick="markConfused()">😕 I'm confused</button>
   </div>
-    </div>
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>


### PR DESCRIPTION
## Summary
- streamline layer1 pages by dropping the outer action-card wrapper around buttons
- leave a single section divider under the action buttons to clean up duplicate lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5efe6b2108331b3f0da7ecd831d25