### PR TITLE
fix: simplify layer3 upsert error handling

### DIFF
--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -77,7 +77,7 @@ async function updateProgress() {
       .upsert(
         { username, point_id: pointId.toLowerCase(), reached_layer: 3 },
         { onConflict: ['username', 'point_id'] }
-      );
+      ).select();
     if (error) console.error('Upsert error:', error);
   }
 }
@@ -128,7 +128,7 @@ async function render() {
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
@@ -150,7 +150,7 @@ async function render() {
             student_answer: textarea.value.trim(),
             correction_note: note,
             corrected_at: new Date().toISOString()
-          }, { onConflict: ['username','point_id','question_number'] });
+          }, { onConflict: ['username','point_id','question_number'] }).select();
           if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -122,14 +122,14 @@ async function render() {
           btn.disabled = true;
           textarea.disabled = true;
           ms.style.display = 'block';
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
             student_answer: ans,
             submitted_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save answer error', error);
             alert('Failed to save answer.');
             return;
@@ -143,7 +143,7 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
-          const { data, error } = await supabase.from(tableName('layer3')).upsert({
+          const { error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),
             question_number: q.question_number,
@@ -151,7 +151,7 @@ async function render() {
             correction_note: note,
             corrected_at: new Date().toISOString()
           }, { onConflict: ['username','point_id','question_number'] });
-          if (error || !data?.length) {
+          if (error) {
             console.error('Save note error', error);
             alert('Failed to save note.');
             return;


### PR DESCRIPTION
## Summary
- Remove data length checks in layer3 Supabase upserts and rely solely on `error`
- Alert only on actual errors across igcse, as, and a level point pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4b6a1488331a1869ae2b160cd8f