### PR TITLE
Re-enable controls after layer3 upsert errors

### DIFF
--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/13.1/layer3.js
+++ b/a/points/13.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/13.2/layer3.js
+++ b/a/points/13.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/13.3/layer3.js
+++ b/a/points/13.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/14.1/layer3.js
+++ b/a/points/14.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/14.2/layer3.js
+++ b/a/points/14.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/15.1/layer3.js
+++ b/a/points/15.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/15.2/layer3.js
+++ b/a/points/15.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/16.1/layer3.js
+++ b/a/points/16.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/16.2/layer3.js
+++ b/a/points/16.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/17/layer3.js
+++ b/a/points/17/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/18/layer3.js
+++ b/a/points/18/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/19.1/layer3.js
+++ b/a/points/19.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/19.2/layer3.js
+++ b/a/points/19.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/20.1/layer3.js
+++ b/a/points/20.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/a/points/20.2/layer3.js
+++ b/a/points/20.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/1.1/layer3.js
+++ b/as/points/1.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/1.2/layer3.js
+++ b/as/points/1.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/1.3/layer3.js
+++ b/as/points/1.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/2/layer3.js
+++ b/as/points/2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/3.1/layer3.js
+++ b/as/points/3.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/3.2/layer3.js
+++ b/as/points/3.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/4.1/layer3.js
+++ b/as/points/4.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/4.2/layer3.js
+++ b/as/points/4.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/4.3/layer3.js
+++ b/as/points/4.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/5/layer3.js
+++ b/as/points/5/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/6/layer3.js
+++ b/as/points/6/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/7/layer3.js
+++ b/as/points/7/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/8.1/layer3.js
+++ b/as/points/8.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/8.2/layer3.js
+++ b/as/points/8.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/as/points/8.3/layer3.js
+++ b/as/points/8.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/1.1/layer3.js
+++ b/igcse/points/1.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/1.2/layer3.js
+++ b/igcse/points/1.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/1.3/layer3.js
+++ b/igcse/points/1.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/2.1/layer3.js
+++ b/igcse/points/2.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/2.2/layer3.js
+++ b/igcse/points/2.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/2.3/layer3.js
+++ b/igcse/points/2.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/3.1/layer3.js
+++ b/igcse/points/3.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/3.2/layer3.js
+++ b/igcse/points/3.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/3.3/layer3.js
+++ b/igcse/points/3.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/3.4/layer3.js
+++ b/igcse/points/3.4/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/4.1/layer3.js
+++ b/igcse/points/4.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/4.2/layer3.js
+++ b/igcse/points/4.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/5.1/layer3.js
+++ b/igcse/points/5.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/5.2/layer3.js
+++ b/igcse/points/5.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/5.3/layer3.js
+++ b/igcse/points/5.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/6.1/layer3.js
+++ b/igcse/points/6.1/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/6.2/layer3.js
+++ b/igcse/points/6.2/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -131,6 +131,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save answer error', error);
+            textarea.disabled = false;
+            btn.disabled = false;
             alert('Failed to save answer.');
             return;
           }
@@ -153,6 +155,8 @@ async function render() {
           }, { onConflict: ['username','point_id','question_number'] });
           if (error || !data?.length) {
             console.error('Save note error', error);
+            noteTA.disabled = false;
+            saveBtn.disabled = false;
             alert('Failed to save note.');
             return;
           }

--- a/igcse/points/6.3/layer3.js
+++ b/igcse/points/6.3/layer3.js
@@ -45,6 +45,8 @@ async function loadSaved() {
 
 function addNoteToReview(qNum, note, time) {
   if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
   const li = document.createElement('li');
   li.textContent = `Q${qNum}: ${note}`;
   notesList.appendChild(li);
@@ -145,6 +147,8 @@ async function render() {
         saveBtn.addEventListener('click', async () => {
           const note = noteTA.value.trim();
           if (!note) return;
+          noteTA.disabled = true;
+          saveBtn.disabled = true;
           const { data, error } = await supabase.from(tableName('layer3')).upsert({
             username,
             point_id: pointId.toLowerCase(),


### PR DESCRIPTION
## Summary
- Re-enable answer textarea and submit button if saving an answer fails across all layer3 pages.
- Re-enable note textarea and save button on note save failures to allow retry.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f4bc9ef08331bfa22524a8ee6d40