### PR TITLE
Add additional resources placeholders to Layer1 pages

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -231,7 +258,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -75,7 +75,7 @@
     }
 
     #video-section {
-      width: 35%;
+      width: 90%;
       margin: 20px auto;
       padding-bottom: 20px;
     }
@@ -89,6 +89,33 @@
 
     .videos iframe {
       height: 250px;
+    }
+
+    .resources-grid {
+      display: flex;
+      gap: 20px;
+    }
+
+    .videos-column, .extras-column {
+      flex: 1;
+    }
+
+    .extras-column {
+      display: flex;
+      flex-direction: column;
+      gap: 20px;
+    }
+
+    .placeholder {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+      height: 250px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
 
     .actions {
@@ -230,7 +257,15 @@
   <div class="section-divider"></div>
     <div id="video-section" class="videos" style="display:none;">
     <div class="section-title">🎥 Additional Resources</div>
-    <div id="videos-container"></div>
+    <div class="resources-grid">
+      <div class="videos-column">
+        <div id="videos-container"></div>
+      </div>
+      <div class="extras-column">
+        <div class="placeholder" id="mind-map-placeholder">🧠 Mind Map (coming soon)</div>
+        <div class="placeholder" id="references-placeholder">📚 Reference Documents (coming soon)</div>
+      </div>
+    </div>
   </div>
 
 


### PR DESCRIPTION
## Summary
- Rework Layer1 "Additional Resources" sections into a two-column layout.
- Left column lists videos from `videos.json`; right column adds placeholders for mind map and reference documents.
- Updates applied across all Layer1 pages.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a603df3e908331ac526e6a599893e9