### PR TITLE
fix(seo): add 301 redirect for 0478 to dashboard or shim page if redirect unavailable

### DIFF
--- a/igcse/computer-science-0478/index.html
+++ b/igcse/computer-science-0478/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="en"><head>
+<meta charset="utf-8">
+<title>Redirecting</title>
+<meta http-equiv="refresh" content="0; url=/igcse/dashboard.html">
+<link rel="canonical" href="https://hamdeni-cs.tn/igcse/dashboard.html">
+<meta name="robots" content="noindex,follow">
+<script>location.replace("/igcse/dashboard.html");</script>
+</head><body>
+<p>If you are not redirected, <a href="/igcse/dashboard.html">continue to the IGCSE page</a>.</p>
+</body></html>


### PR DESCRIPTION
## Summary
- add HTML shim page under `/igcse/computer-science-0478` that redirects to `dashboard.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a63fe6eee88331bcaacb91077f3555