### PR TITLE
Show notice for unavailable action buttons

### DIFF
--- a/a/exercises.css
+++ b/a/exercises.css
@@ -389,6 +389,19 @@ a{ color:inherit; text-decoration:none }
   color: #ffffff;
 }
 
+.content > .footer:last-of-type .action-unavailable-note {
+  width: 100%;
+  margin: 8px 0 0;
+  font-size: 0.95rem;
+  color: #a94442;
+  text-align: center;
+  line-height: 1.4;
+}
+
+.content > .footer:last-of-type .action-unavailable-note[hidden] {
+  display: none;
+}
+
 /* White text for the two action buttons in the modal */
 .mock-modal-actions.footer .btn,
 .mock-modal-actions.footer .btn.ghost,

--- a/a/exercises.js
+++ b/a/exercises.js
@@ -182,6 +182,34 @@
     return mid;
   }
 
+  function setupUnavailableNotice(){
+    var footer = qs('footer.footer'); if (!footer) return;
+    var btns = Array.prototype.slice.call(footer.querySelectorAll('button, a'));
+    var left = btns.find(b => /i need help/i.test(text(b)));
+    var right = btns.find(b => /i'?m ready for the test/i.test(text(b)));
+    var targets = [left, right].filter(Boolean);
+    if (targets.length === 0) return;
+
+    var messageId = 'ctaUnavailableNotice';
+    var message = qsid(messageId);
+    if (!message) {
+      message = document.createElement('p');
+      message.id = messageId;
+      message.className = 'action-unavailable-note';
+      message.textContent = 'Inform the teacher directly, this button is not implemented yet.';
+      message.setAttribute('role', 'status');
+      message.setAttribute('aria-live', 'polite');
+      message.hidden = true;
+      footer.appendChild(message);
+    }
+
+    targets.forEach(function(btn){
+      btn.addEventListener('click', function(){
+        if (message.hidden) message.hidden = false;
+      });
+    });
+  }
+
   function openModal(){
     var m = qsid('mockTestModal'); if(!m) return;
     m.setAttribute('aria-hidden','false');
@@ -227,6 +255,7 @@
 
   function init(){
     ensureMiddleButton();   // clones left button so style is identical
+    setupUnavailableNotice();
     populateFromJSON();     // fixes \n and \u2190 by using proper JSON escapes
     wireModal();
   }


### PR DESCRIPTION
## Summary
- show a notice below the "I need help" and "I'm ready for the test" buttons when they are clicked
- style the notice so it aligns with the existing footer layout

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c9bda0778c8331918b55ab871fee20