### PR TITLE
Allow strong tags to render in exercise text

### DIFF
--- a/a/exercises.js
+++ b/a/exercises.js
@@ -28,8 +28,26 @@
       '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'
     })[s]);
   }
+  const ALLOWED_INLINE_TAGS = ['strong'];
   function formatMultiline(text){
-    return escapeHTML(text).replace(/\n/g,'<br>');
+    const placeholders = [];
+    const withPlaceholders = String(text).replace(/<\/?([a-z0-9]+)>/gi, (match, tagName) => {
+      if (ALLOWED_INLINE_TAGS.includes(tagName.toLowerCase())) {
+        const token = `__HTML_TAG_${placeholders.length}__`;
+        placeholders.push({ token, value: match });
+        return token;
+      }
+      return match;
+    });
+
+    let escaped = escapeHTML(withPlaceholders).replace(/\n/g, '<br>');
+
+    placeholders.forEach(({ token, value }) => {
+      const re = new RegExp(token, 'g');
+      escaped = escaped.replace(re, value);
+    });
+
+    return escaped;
   }
   function hasExplanation(text){
     return typeof text === 'string' && text.trim() !== '';


### PR DESCRIPTION
## Summary
- preserve <strong> tags in exercise/question text while still escaping other HTML entities
- ensure multiline formatting continues to convert newlines into <br> elements after sanitising content

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cbebbdb4508331af631366b6fb2d6e