### PR TITLE
Add heading to Layer 1 action buttons

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -245,6 +252,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -122,7 +122,14 @@
       display: flex;
       justify-content: center;
       gap: 15px;
+      flex-wrap: wrap;
       margin-top: 30px;
+    }
+
+    .actions-heading {
+      flex-basis: 100%;
+      text-align: center;
+      margin: 0;
     }
 
     .help-wrapper {
@@ -244,6 +251,7 @@
   <iframe id="doc-frame" class="official-doc" scrolling="no" ></iframe>
   </main>
   <div class="actions">
+    <h2 class="actions-heading">Move to Layer 2</h2>
     <button class="highlight-button btn-clear" onclick="markClear()">✅ Notes are clear</button>
     <div class="help-wrapper">
       <button class="highlight-button btn-help" onclick="showHelp()">🆘 Need help</button>


### PR DESCRIPTION
## Summary
- add a "Move to Layer 2" heading to the action section on every Layer 1 page
- allow the action row to wrap so the heading sits above the existing buttons

## Testing
- not run (static HTML update)


------
https://chatgpt.com/codex/tasks/task_e_68ce6767cd748331aa5d723eeb88f582