### PR TITLE
Allow guest users to proceed from first point layer1

### DIFF
--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -294,12 +294,15 @@
   const storedStudentName = localStorage.getItem("student_name");
   const storedPlatform = localStorage.getItem("platform");
 
-  if (storedStudentName) {
-    document.getElementById("student-name").textContent = "👤 " + storedStudentName;
+  const studentNameEl = document.getElementById("student-name");
+  if (studentNameEl) {
+    studentNameEl.textContent = "👤 " + (storedStudentName || "Guest");
   }
 
-  if (storedPlatform) {
-    document.getElementById("platform-name").textContent = "🎓 Platform: " + storedPlatform;
+  const platformNameEl = document.getElementById("platform-name");
+  if (platformNameEl) {
+    const displayPlatform = storedPlatform || "A Level (Guest)";
+    platformNameEl.textContent = "🎓 Platform: " + displayPlatform;
   }
 
   fetch("../index.json")
@@ -342,16 +345,19 @@
     const platform = localStorage.getItem("platform");
 
     if (!username || !platform) {
-      alert("👋 Please log in to interact with this content.");
-      return null;
+      return { guest: true };
     }
 
-    return { username, platform };
+    return { guest: false, username, platform };
   }
 
   async function updateProgress(session = ensureSession()) {
     if (!session) {
       return false;
+    }
+
+    if (session.guest) {
+      return true;
     }
 
     const { username, platform } = session;
@@ -399,6 +405,10 @@
   async function sendFeedback(feedback_type, comment = "", session = ensureSession()) {
     if (!session) {
       return false;
+    }
+
+    if (session.guest) {
+      return true;
     }
 
     const { username, platform } = session;

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -294,57 +294,71 @@
   const platform = localStorage.getItem("platform");
   const point_id = "1.1";
 
-  if (!username || !student_name) {
-    document.getElementById("error-message").style.display = "block";
-  } else {
-    document.getElementById("student-name").textContent = "👤 " + student_name;
-    document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
-    document.getElementById("content-area").style.display = "block";
+  const errorMessageEl = document.getElementById("error-message");
+  const contentAreaEl = document.getElementById("content-area");
+  const studentNameEl = document.getElementById("student-name");
+  const platformNameEl = document.getElementById("platform-name");
 
-    fetch("../index.json")
-      .then(res => res.json())
-      .then(list => {
-        const found = list.find(p => p.id.toLowerCase() === point_id.toLowerCase());
-        if (found) {
-          document.getElementById("point-title").textContent = "📍 " + found.title;
-        }
-      });
-
-    fetch("videos.json")
-      .then(res => res.json())
-      .then(data => {
-        if (data[point_id]) {
-          const { videos = [], doc } = data[point_id];
-
-          if (doc) {
-            const frame = document.getElementById("doc-frame");
-            frame.src = doc.url;
-            const height = 4750;
-            
-            
-          }
-
-          if (videos.length > 0) {
-            document.getElementById("video-section").style.display = "block";
-            const container = document.getElementById("videos-container");
-            videos.forEach(video => {
-              const wrapper = document.createElement("div");
-              wrapper.innerHTML = video.iframe;
-              wrapper.style.marginBottom = "20px";
-              container.appendChild(wrapper);
-            });
-          }
-        }
-      });
+  const displayName = student_name || "Guest";
+  if (displayName && studentNameEl) {
+    studentNameEl.textContent = "👤 " + displayName;
   }
+
+  const displayPlatform = platform || "AS Level (Guest)";
+  if (platformNameEl) {
+    platformNameEl.textContent = "🎓 Platform: " + displayPlatform;
+  }
+
+  if (errorMessageEl) {
+    errorMessageEl.style.display = "none";
+  }
+
+  if (contentAreaEl) {
+    contentAreaEl.style.display = "block";
+  }
+
+  fetch("../index.json")
+    .then(res => res.json())
+    .then(list => {
+      const found = list.find(p => p.id.toLowerCase() === point_id.toLowerCase());
+      if (found) {
+        document.getElementById("point-title").textContent = "📍 " + found.title;
+      }
+    });
+
+  fetch("videos.json")
+    .then(res => res.json())
+    .then(data => {
+      if (data[point_id]) {
+        const { videos = [], doc } = data[point_id];
+
+        if (doc) {
+          const frame = document.getElementById("doc-frame");
+          frame.src = doc.url;
+          const height = 4750;
+
+
+        }
+
+        if (videos.length > 0) {
+          document.getElementById("video-section").style.display = "block";
+          const container = document.getElementById("videos-container");
+          videos.forEach(video => {
+            const wrapper = document.createElement("div");
+            wrapper.innerHTML = video.iframe;
+            wrapper.style.marginBottom = "20px";
+            container.appendChild(wrapper);
+          });
+        }
+      }
+    });
 
   async function updateProgress() {
     const platform = localStorage.getItem("platform");
     const username = localStorage.getItem("username");
 
     if (!username || !platform) {
-      alert("❌ Missing student information. Please log in again.");
-      return false;
+      return true;
     }
 
     const tables = {
@@ -383,11 +397,19 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    if (!username || !platform) {
+      return;
+    }
+
     const feedbackTable = {
       A_Level: 'a_theory_feedback',
       AS_Level: 'as_theory_feedback',
       IGCSE: 'igcse_theory_feedback'
     }[platform];
+
+    if (!feedbackTable) {
+      return;
+    }
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -294,57 +294,71 @@
   const platform = localStorage.getItem("platform");
   const point_id = "1.1";
 
-  if (!username || !student_name) {
-    document.getElementById("error-message").style.display = "block";
-  } else {
-    document.getElementById("student-name").textContent = "👤 " + student_name;
-    document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
-    document.getElementById("content-area").style.display = "block";
+  const errorMessageEl = document.getElementById("error-message");
+  const contentAreaEl = document.getElementById("content-area");
+  const studentNameEl = document.getElementById("student-name");
+  const platformNameEl = document.getElementById("platform-name");
 
-    fetch("../index.json")
-      .then(res => res.json())
-      .then(list => {
-        const found = list.find(p => p.id.toLowerCase() === point_id.toLowerCase());
-        if (found) {
-          document.getElementById("point-title").textContent = "📍 " + found.title;
-        }
-      });
-
-    fetch("videos.json")
-      .then(res => res.json())
-      .then(data => {
-        if (data[point_id]) {
-          const { videos = [], doc } = data[point_id];
-
-          if (doc) {
-            const frame = document.getElementById("doc-frame");
-            frame.addEventListener("load", function() {
-              this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
-            });
-            frame.src = doc.url;
-          }
-
-          if (videos.length > 0) {
-            document.getElementById("video-section").style.display = "block";
-            const container = document.getElementById("videos-container");
-            videos.forEach(video => {
-              const wrapper = document.createElement("div");
-              wrapper.innerHTML = video.iframe;
-              wrapper.style.marginBottom = "20px";
-              container.appendChild(wrapper);
-            });
-          }
-        }
-      });
+  const displayName = student_name || "Guest";
+  if (displayName && studentNameEl) {
+    studentNameEl.textContent = "👤 " + displayName;
   }
+
+  const displayPlatform = platform || "IGCSE (Guest)";
+  if (platformNameEl) {
+    platformNameEl.textContent = "🎓 Platform: " + displayPlatform;
+  }
+
+  if (errorMessageEl) {
+    errorMessageEl.style.display = "none";
+  }
+
+  if (contentAreaEl) {
+    contentAreaEl.style.display = "block";
+  }
+
+  fetch("../index.json")
+    .then(res => res.json())
+    .then(list => {
+      const found = list.find(p => p.id.toLowerCase() === point_id.toLowerCase());
+      if (found) {
+        document.getElementById("point-title").textContent = "📍 " + found.title;
+      }
+    });
+
+  fetch("videos.json")
+    .then(res => res.json())
+    .then(data => {
+      if (data[point_id]) {
+        const { videos = [], doc } = data[point_id];
+
+        if (doc) {
+          const frame = document.getElementById("doc-frame");
+          frame.addEventListener("load", function() {
+            this.style.height = this.contentWindow.document.documentElement.scrollHeight + "px";
+          });
+          frame.src = doc.url;
+        }
+
+        if (videos.length > 0) {
+          document.getElementById("video-section").style.display = "block";
+          const container = document.getElementById("videos-container");
+          videos.forEach(video => {
+            const wrapper = document.createElement("div");
+            wrapper.innerHTML = video.iframe;
+            wrapper.style.marginBottom = "20px";
+            container.appendChild(wrapper);
+          });
+        }
+      }
+    });
 
   async function updateProgress() {
     const platform = localStorage.getItem("platform");
     const username = localStorage.getItem("username");
 
     if (!username || !platform) {
-      alert("❌ Missing student information. Please log in again.");
-      return false;
+      return true;
     }
 
     const tables = {
@@ -383,11 +397,19 @@
   }
 
   async function sendFeedback(feedback_type, comment = "") {
+    if (!username || !platform) {
+      return;
+    }
+
     const feedbackTable = {
       A_Level: 'a_theory_feedback',
       AS_Level: 'as_theory_feedback',
       IGCSE: 'igcse_theory_feedback'
     }[platform];
+
+    if (!feedbackTable) {
+      return;
+    }
     const fullFeedback = comment
       ? `${feedback_type}: ${comment}`
       : feedback_type;


### PR DESCRIPTION
## Summary
- allow guest visitors on each platform's first point Layer 1 page to see the content without the login warning
- skip Supabase progress and feedback writes when no student session exists so guest users can continue to Layer 2

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68ce84c2cd4c8331ad31db2d5bb40324