### PR TITLE
Remove grey pseudo-element arrows from dashboards

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -781,17 +781,6 @@ body {
   line-height: 1.2;
 }
 
-/* Arrows between levels */
-.level-box:not(:last-child)::after {
-  content: "↓";
-  position: absolute;
-  bottom: -20px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 18px;
-  color: #aaa;
-}
-
 .arrow-img {
   width: 20px;
   height: auto;

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -400,16 +400,6 @@ body {
 .level-text {
   line-height: 1.2;
 }
-/* Arrows between levels */
-.level-box:not(:last-child)::after {
-  content: "↓";
-  position: absolute;
-  bottom: -20px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 18px;
-  color: #aaa;
-}
 /* Divider between left and right */
 .dashboard {
   display: flex;
@@ -448,21 +438,6 @@ body {
   background-color: #4CAF50;
   width: 0%;
   border-radius: 10px 0 0 10px;
-}
-/* Remove ↓ arrows and add nice connecting line */
-.level-box:not(:last-child)::after {
-  content: "";
-  position: absolute;
-  bottom: -25px;
-  left: 50%;
-  width: 2px;
-  height: 25px;
-  background-color: #ccc;
-  transform: translateX(-50%);
-}
-/* Remove old arrow line */
-.level-box::after {
-  display: none !important;
 }
 /* Insert PNG-based arrow between levels */
 .arrow-img {

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -417,16 +417,6 @@ body {
 .level-text {
   line-height: 1.2;
 }
-/* Arrows between levels */
-.level-box:not(:last-child)::after {
-  content: "↓";
-  position: absolute;
-  bottom: -20px;
-  left: 50%;
-  transform: translateX(-50%);
-  font-size: 18px;
-  color: #aaa;
-}
 /* Divider between left and right */
 .dashboard {
   display: flex;
@@ -465,21 +455,6 @@ body {
   background-color: #4CAF50;
   width: 0%;
   border-radius: 10px 0 0 10px;
-}
-/* Remove ↓ arrows and add nice connecting line */
-.level-box:not(:last-child)::after {
-  content: "";
-  position: absolute;
-  bottom: -25px;
-  left: 50%;
-  width: 2px;
-  height: 25px;
-  background-color: #ccc;
-  transform: translateX(-50%);
-}
-/* Remove old arrow line */
-.level-box::after {
-  display: none !important;
 }
 /* Insert PNG-based arrow between levels */
 .arrow-img {


### PR DESCRIPTION
## Summary
- remove the legacy `.level-box::after` CSS that rendered an extra grey down arrow above each level-to-level connector
- keep the PNG arrow styling so the red arrow remains the only arrow shown between cards across the A Level, AS Level, and IGCSE dashboards

## Testing
- not run (static assets change only)

------
https://chatgpt.com/codex/tasks/task_e_68ce8c553c1883319a4f6bc96be803f1