### PR TITLE
Ensure level 1 is auto-passed for all platforms

### DIFF
--- a/a/modules/levelRenderer.js
+++ b/a/modules/levelRenderer.js
@@ -28,7 +28,14 @@ export async function renderProgrammingLevels() {
     return;
   }
 
-  const { levels: reached = 0 } = await fetchProgressCounts();
+  const progress = await fetchProgressCounts();
+  let reached = Number(progress?.levels ?? 0);
+  if (!Number.isFinite(reached)) {
+    reached = 0;
+  }
+  if (reached < 2) {
+    reached = 2;
+  }
 
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);

--- a/as/modules/levelRenderer.js
+++ b/as/modules/levelRenderer.js
@@ -28,7 +28,14 @@ export async function renderProgrammingLevels() {
     return;
   }
 
-  const { levels: reached = 0 } = await fetchProgressCounts();
+  const progress = await fetchProgressCounts();
+  let reached = Number(progress?.levels ?? 0);
+  if (!Number.isFinite(reached)) {
+    reached = 0;
+  }
+  if (reached < 2) {
+    reached = 2;
+  }
 
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);

--- a/igcse/modules/levelRenderer.js
+++ b/igcse/modules/levelRenderer.js
@@ -28,7 +28,14 @@ export async function renderProgrammingLevels() {
     return;
   }
 
-  const { levels: reached = 0 } = await fetchProgressCounts();
+  const progress = await fetchProgressCounts();
+  let reached = Number(progress?.levels ?? 0);
+  if (!Number.isFinite(reached)) {
+    reached = 0;
+  }
+  if (reached < 2) {
+    reached = 2;
+  }
 
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);


### PR DESCRIPTION
## Summary
- ensure each platform's level renderer coerces stored progress counts to a number
- default the reached level to at least level 2 so that level 1 is always open and level 2 is the starting point

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ceb1bf0e148331bdcef8c22eb8f57e