### PR TITLE
Simplify Layer 3 reminder heading

### DIFF
--- a/a/points/13.1/layer3.html
+++ b/a/points/13.1/layer3.html
@@ -138,6 +138,17 @@
 	.task-box h3,
 .task-box .mark-scheme { white-space: pre-line; }
 
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -165,6 +176,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/13.2/layer3.html
+++ b/a/points/13.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/13.3/layer3.html
+++ b/a/points/13.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/14.1/layer3.html
+++ b/a/points/14.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/14.2/layer3.html
+++ b/a/points/14.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/15.1/layer3.html
+++ b/a/points/15.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/15.2/layer3.html
+++ b/a/points/15.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/16.1/layer3.html
+++ b/a/points/16.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/16.2/layer3.html
+++ b/a/points/16.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/17/layer3.html
+++ b/a/points/17/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/18/layer3.html
+++ b/a/points/18/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/19.1/layer3.html
+++ b/a/points/19.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/19.2/layer3.html
+++ b/a/points/19.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/20.1/layer3.html
+++ b/a/points/20.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/a/points/20.2/layer3.html
+++ b/a/points/20.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/1.1/layer3.html
+++ b/as/points/1.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/1.2/layer3.html
+++ b/as/points/1.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/1.3/layer3.html
+++ b/as/points/1.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/2/layer3.html
+++ b/as/points/2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/3.1/layer3.html
+++ b/as/points/3.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/3.2/layer3.html
+++ b/as/points/3.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/4.1/layer3.html
+++ b/as/points/4.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/4.2/layer3.html
+++ b/as/points/4.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/4.3/layer3.html
+++ b/as/points/4.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/5/layer3.html
+++ b/as/points/5/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/6/layer3.html
+++ b/as/points/6/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/7/layer3.html
+++ b/as/points/7/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/8.1/layer3.html
+++ b/as/points/8.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/8.2/layer3.html
+++ b/as/points/8.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/as/points/8.3/layer3.html
+++ b/as/points/8.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/1.1/layer3.html
+++ b/igcse/points/1.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/1.2/layer3.html
+++ b/igcse/points/1.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/1.3/layer3.html
+++ b/igcse/points/1.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/2.1/layer3.html
+++ b/igcse/points/2.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/2.2/layer3.html
+++ b/igcse/points/2.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/2.3/layer3.html
+++ b/igcse/points/2.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/3.1/layer3.html
+++ b/igcse/points/3.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/3.2/layer3.html
+++ b/igcse/points/3.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/3.3/layer3.html
+++ b/igcse/points/3.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/3.4/layer3.html
+++ b/igcse/points/3.4/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/4.1/layer3.html
+++ b/igcse/points/4.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/4.2/layer3.html
+++ b/igcse/points/4.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/5.1/layer3.html
+++ b/igcse/points/5.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/5.2/layer3.html
+++ b/igcse/points/5.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/5.3/layer3.html
+++ b/igcse/points/5.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/6.1/layer3.html
+++ b/igcse/points/6.1/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/6.2/layer3.html
+++ b/igcse/points/6.2/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">

--- a/igcse/points/6.3/layer3.html
+++ b/igcse/points/6.3/layer3.html
@@ -135,6 +135,18 @@
       max-width: 900px;
       margin: 0 auto;
     }
+
+    .post-submission-heading {
+      margin: 30px 0;
+      padding: 18px 24px;
+      background: linear-gradient(135deg, #fff4e6, #fffaf0);
+      border-left: 6px solid #f2994a;
+      border-radius: 12px;
+      color: #6b3b0f;
+      font-size: 1.2em;
+      line-height: 1.5;
+      box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
+    }
   </style>
 </head>
 <body>
@@ -162,6 +174,7 @@
   </div>
 
   <main style="padding:40px;">
+    <h2 class="post-submission-heading">After submitting your work, check your answers against the mark scheme and record any weaknesses in your personal notes for future review.</h2>
     <div id="questions-container"></div>
 
     <div style="text-align:center; margin:20px;">


### PR DESCRIPTION
## Summary
- replace the previous reminder block with a single guidance heading at the top of every Layer 3 question page
- style the new `.post-submission-heading` element so the instruction text remains prominent without extra supporting copy

## Testing
- not run (HTML-only change)

------
https://chatgpt.com/codex/tasks/task_e_68ceb0a795988331baa1cfc875b9403a