### PR TITLE
Show warning when hovering disabled Layer 4 button

### DIFF
--- a/layer3-shared.js
+++ b/layer3-shared.js
@@ -35,6 +35,16 @@ export default function initLayer3(pointId, options = {}) {
   const layer4Btn = document.getElementById('layer4-btn');
   const notesTitle = document.getElementById('notes-title');
 
+  const LAYER4_DISABLED_MESSAGE = 'finish all questions before moveing to layer 4';
+
+  if (layer4Btn) {
+    layer4Btn.addEventListener('mouseenter', () => {
+      if (layer4Btn.disabled) {
+        alert(LAYER4_DISABLED_MESSAGE);
+      }
+    });
+  }
+
   let totalQuestions = 0;
   const savedNotes = new Set();
   const questionLabels = new Map();


### PR DESCRIPTION
## Summary
- alert students when hovering the disabled "Go to Layer 4" button before completing questions

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cee6387e8c8331bc98031768c5d70d