### PR TITLE
Add semantic states to dashboard progress bar

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -200,6 +200,21 @@ body {
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4) !important;
 }
 
+.header-background + .header-row .general-progress-fill.progress-low {
+  background: linear-gradient(90deg, #ef4444 0%, #f97316 100%) !important;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-medium {
+  background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%) !important;
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-high {
+  background: linear-gradient(90deg, #10b981 0%, #059669 100%) !important;
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.45) !important;
+}
+
 @keyframes finalHeaderGradientFlow {
   0% { background-position: 0% 50%; }
   50% { background-position: 100% 50%; }

--- a/a/dashboard.js
+++ b/a/dashboard.js
@@ -29,6 +29,17 @@ async function updateGeneralProgress() {
 
   fill.style.width = percent + "%";
   fill.textContent = percent + "%";
+
+  fill.classList.remove("progress-low", "progress-medium", "progress-high");
+
+  let progressClass = "progress-low";
+  if (percent >= 67) {
+    progressClass = "progress-high";
+  } else if (percent >= 34) {
+    progressClass = "progress-medium";
+  }
+
+  fill.classList.add(progressClass);
   console.debug('[dashboard] Progress percent', percent);
 }
 


### PR DESCRIPTION
## Summary
- add semantic progress state classes to dashboard progress bar updates
- style each state with themed gradients reflecting progress ranges
- ensure state classes are reset on each update to avoid stacking

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf1cee67508331befcbac9af2784d2