### PR TITLE
Adjust contact info spacing on dashboards

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -315,8 +315,8 @@ body {
 }
 
 .header-background + .header-row .contact-info {
-  margin-top: 15px !important;
-  padding-top: 15px !important;
+  margin-top: 12px !important;
+  padding-top: 8px !important;
   border-top: 1px solid rgba(226, 232, 240, 0.5) !important;
   font-size: 13px !important;
   color: #64748b !important;

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -315,8 +315,8 @@ body {
 }
 
 .header-background + .header-row .contact-info {
-  margin-top: 15px !important;
-  padding-top: 15px !important;
+  margin-top: 12px !important;
+  padding-top: 8px !important;
   border-top: 1px solid rgba(226, 232, 240, 0.5) !important;
   font-size: 13px !important;
   color: #64748b !important;

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -315,8 +315,8 @@ body {
 }
 
 .header-background + .header-row .contact-info {
-  margin-top: 15px !important;
-  padding-top: 15px !important;
+  margin-top: 12px !important;
+  padding-top: 8px !important;
   border-top: 1px solid rgba(226, 232, 240, 0.5) !important;
   font-size: 13px !important;
   color: #64748b !important;


### PR DESCRIPTION
## Summary
- Reduce the margin and padding above the contact-info block so the contact line sits closer to its divider on the A, AS, and IGCSE dashboards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf1d2a68508331a3efae70df893775