### PR TITLE
Update feature popover hover behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -739,25 +739,6 @@ footer {
   display: block;
 }
 
-.chip-popover-close {
-  position: absolute;
-  top: 6px;
-  right: 8px;
-  appearance: none;
-  background: transparent;
-  border: none;
-  font-size: 22px;
-  line-height: 1;
-  color: #5a7e92;
-  cursor: pointer;
-  border-radius: 6px;
-}
-.chip-popover-close:hover,
-.chip-popover-close:focus {
-  background: #f3faff;
-  outline: 2px solid transparent;
-}
-
 .modern-divider {
   border: none;
   height: 2px;

--- a/index.html
+++ b/index.html
@@ -136,7 +136,6 @@ window.addEventListener('DOMContentLoaded', function() {
   const chips = document.querySelectorAll('.feature-chip.has-popover');
   const pop = document.getElementById('chipPopover');
   const img = document.getElementById('chipPopoverImg');const text = document.getElementById('chipPopoverText');
-  const closeBtn = pop.querySelector('.chip-popover-close');
   let activeChip = null;
 
   function clamp(val, min, max){ return Math.min(Math.max(val, min), max); }
@@ -204,7 +203,6 @@ window.addEventListener('DOMContentLoaded', function() {
     });
   });
 
-  closeBtn.addEventListener('click', closePopover);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape') closePopover(); });
 
   // Click outside to close
@@ -213,6 +211,8 @@ window.addEventListener('DOMContentLoaded', function() {
       closePopover();
     }
   });
+
+  pop.addEventListener('mouseleave', closePopover);
 
   // Reposition on resize/scroll if visible
   window.addEventListener('resize', () => { if (activeChip) openPopoverFor(activeChip); });
@@ -226,7 +226,6 @@ window.addEventListener('DOMContentLoaded', function() {
   
   <!-- Reusable chip popover (text first, then image; single column) -->
   <div id="chipPopover" class="chip-popover" role="dialog" aria-hidden="true">
-    <button class="chip-popover-close" aria-label="Close">&times;</button>
     <div class="chip-popover-content">
       <div class="chip-popover-text">
         <p id="chipPopoverText"></p>


### PR DESCRIPTION
## Summary
- remove the close button from the feature chip popovers on the landing page
- automatically dismiss the popover when the cursor leaves its window while keeping existing keyboard and click dismissal

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cfb2caf7e48331859a1c3624a2f418