### PR TITLE
Ensure 13.3 doc notifies parent about height changes

### DIFF
--- a/a/points/13.3/doc.html
+++ b/a/points/13.3/doc.html
@@ -571,7 +571,7 @@
     <script>
         function toggleExplanation(button) {
             const explanation = button.nextElementSibling;
-            
+
             if (explanation && explanation.classList.contains('explanatory-example')) {
                 if (explanation.classList.contains('show')) {
                     explanation.classList.remove('show');
@@ -582,8 +582,18 @@
                     button.textContent = 'Hide Detailed Explanation';
                     button.style.background = 'linear-gradient(135deg, #4ecdc4, #44a08d)';
                 }
+
+                setTimeout(notifyParentHeight, 0);
             }
         }
+    </script>
+    <script>
+        function notifyParentHeight() {
+            const height = document.body.scrollHeight;
+            window.parent.postMessage({ type: 'resize', height }, '*');
+        }
+
+        window.addEventListener('load', notifyParentHeight);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a reusable helper in the 13.3 floating-point guide to report iframe height changes to the parent page
- trigger the helper on page load and after explanation toggles so embedded views resize correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cfb6868e90833197b6af96f0d6110c