### PR TITLE
Fix JSON structure for A Level 13.2 videos

### DIFF
--- a/a/points/13.2/videos.json
+++ b/a/points/13.2/videos.json
@@ -44,5 +44,6 @@
         "title": "A levels Computer Science 9618 - A2 File Organization and Access Types",
         "iframe": "<iframe width=\"560\" height=\"315\" src=\"https://www.youtube.com/embed/s5Dj2GyqbMU\" title=\"YouTube video player\" frameborder=\"0\" allow=\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share\" referrerpolicy=\"strict-origin-when-cross-origin\" allowfullscreen></iframe>"
       }
-     ]
+    ]
   }
+}


### PR DESCRIPTION
## Summary
- add the missing closing delimiters to `a/points/13.2/videos.json` so the JSON parses correctly

## Testing
- python -m json.tool a/points/13.2/videos.json
- Manually served the site locally and opened `a/points/13.2/layer1.html` to confirm the document iframe and Additional Resources load

------
https://chatgpt.com/codex/tasks/task_e_68cfe332def08331a722ef1fe20ae624