### PR TITLE
Add site-wide Paste Guard that blocks all paste and drop and flags [CP] attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,42 @@ For client-side fallback, you can add JavaScript redirect if needed.
 Supabase Configuration
 ----------------------
 The frontend now contains the Supabase URL, service key and teacher password directly in the JavaScript source. No external `config.js` file is required for deployment.
+
+Paste Guard ([CP] protection)
+-----------------------------
+- A site-wide Paste Guard (`assets/js/paste-guard.js`) runs on every page to block paste, drag-drop and keyboard paste shortcuts for guarded inputs and textareas.
+- When a paste attempt occurs, an inline accessible warning appears and a hidden `<fieldName>__cp` field with value `1` is appended to the same form. The backend can tag the response with `[CP]` using this flag.
+- Optional overrides can be configured globally by setting `window.PASTE_GUARD_CONFIG = { allowSelector: 'input[name="email"]' }` before the guard loads.
+- The guard is injected automatically into every HTML response by the lightweight Node server (`server/app.js`).
+
+Running the server locally
+--------------------------
+
+```
+npm start
+```
+
+This serves the static site with the Paste Guard injected into every page and exposes a `/submissions` endpoint that normalises `[CP]` flags.
+
+Automated tests
+----------------
+
+```
+npm test
+```
+
+The test suite covers the client-side guard behaviour (paste/drop/keyboard blocking, warnings, allowlist, hidden flag handling) and backend helpers plus HTML injection.
+
+Demo
+----
+
+Paste Guard prevents paste attempts in three ways:
+
+1. Try pasting text into any guarded input – the attempt is blocked and an inline "Pasting is disabled" message appears.
+2. Drag text onto the field or use Ctrl/Cmd+V (or Shift+Insert) – both are intercepted, the same warning is shown, and the hidden `__cp` flag is attached to the form.
+3. Submit the form – the backend receives the original field value plus the optional `[CP]` flag so responses can be tagged.
+
+If you prefer a visual walkthrough, host a clip or GIF on your media CDN (e.g. Loom, Vimeo, Google Drive) and link to it from this section.
 # Database Schema
 
 Legend: PK=Primary Key, FK=Foreign Key, Nullable=YES if column allows NULL.

--- a/assets/js/paste-guard.js
+++ b/assets/js/paste-guard.js
@@ -1,0 +1,129 @@
+(function () {
+  "use strict";
+
+  // Optional runtime configuration
+  // window.PASTE_GUARD_CONFIG = {
+  //   allowSelector: 'input[name="email"]',
+  //   warnDuration: 2000,
+  //   message: 'Custom warning text',
+  //   selectorList: ['input[type="text"]', 'textarea']
+  // };
+
+  const globalConfig = window.PASTE_GUARD_CONFIG || {};
+  const DEFAULT_ALLOW = "";
+  const ALLOW_PASTE_SELECTOR = typeof globalConfig.allowSelector === "string"
+    ? globalConfig.allowSelector
+    : (window.PASTE_GUARD_ALLOW_SELECTOR || DEFAULT_ALLOW);
+
+  const WARN_MS = Number.isFinite(globalConfig.warnDuration)
+    ? Math.max(0, Number(globalConfig.warnDuration))
+    : 2500;
+
+  const WARN_MESSAGE = typeof globalConfig.message === "string"
+    ? globalConfig.message
+    : "Pasting is disabled here. Please type your answer.";
+
+  const GUARDED_SELECTOR = (globalConfig.selectorList || [
+    'input[type="text"]',
+    'input[type="search"]',
+    'input[type="email"]',
+    'input[type="url"]',
+    'input[type="tel"]',
+    'input[type="number"]',
+    'input[type="password"]',
+    'textarea'
+  ]).join(', ');
+
+  const EXCLUDE_SELECTOR = 'input[readonly], input[disabled], textarea[readonly], textarea[disabled]';
+
+  const hiddenFlags = new WeakMap();
+  const warnings = new WeakMap();
+
+  function isGuarded(el) {
+    if (!(el instanceof HTMLElement)) return false;
+    if (!el.matches(GUARDED_SELECTOR)) return false;
+    if (el.matches(EXCLUDE_SELECTOR)) return false;
+    if (ALLOW_PASTE_SELECTOR && el.matches(ALLOW_PASTE_SELECTOR)) return false;
+    return true;
+  }
+
+  function ensureHiddenFlag(el) {
+    if (!el || !el.form || !el.name) return null;
+    if (hiddenFlags.has(el)) return hiddenFlags.get(el);
+
+    const hidden = document.createElement('input');
+    hidden.type = 'hidden';
+    hidden.name = el.name + '__cp';
+    hidden.value = '1';
+    el.form.appendChild(hidden);
+    hiddenFlags.set(el, hidden);
+    return hidden;
+  }
+
+  function showWarning(el) {
+    if (!el) return;
+    let warn = warnings.get(el);
+    if (!warn) {
+      warn = document.createElement('div');
+      warn.className = 'pg-warning';
+      warn.setAttribute('role', 'alert');
+      warn.setAttribute('aria-live', 'polite');
+      Object.assign(warn.style, {
+        fontSize: '0.9rem',
+        marginTop: '4px',
+        color: '#b00020',
+        display: 'none'
+      });
+      el.insertAdjacentElement('afterend', warn);
+      warnings.set(el, warn);
+    }
+    warn.textContent = WARN_MESSAGE;
+    warn.style.display = 'block';
+    clearTimeout(warn._hideTimer);
+    warn._hideTimer = window.setTimeout(() => {
+      warn.style.display = 'none';
+    }, WARN_MS);
+  }
+
+  function blockAndFlag(event) {
+    const target = event.target;
+    if (!isGuarded(target)) return;
+    event.preventDefault();
+    ensureHiddenFlag(target);
+    showWarning(target);
+  }
+
+  function onPaste(event) {
+    blockAndFlag(event);
+  }
+
+  function onDrop(event) {
+    blockAndFlag(event);
+  }
+
+  function onKeydown(event) {
+    const target = event.target;
+    if (!isGuarded(target)) return;
+    const key = String(event.key).toLowerCase();
+    const combo = ((event.ctrlKey || event.metaKey) && key === 'v') || (event.shiftKey && key === 'insert');
+    if (!combo) return;
+    event.preventDefault();
+    ensureHiddenFlag(target);
+    showWarning(target);
+  }
+
+  function onBeforeInput(event) {
+    const target = event.target;
+    if (!isGuarded(target)) return;
+    if (event.inputType === 'insertFromPaste' || event.inputType === 'insertFromDrop') {
+      event.preventDefault();
+      ensureHiddenFlag(target);
+      showWarning(target);
+    }
+  }
+
+  document.addEventListener('paste', onPaste, true);
+  document.addEventListener('drop', onDrop, true);
+  document.addEventListener('keydown', onKeydown, true);
+  document.addEventListener('beforeinput', onBeforeInput, true);
+})();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "hamdeni-platform",
+  "version": "1.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node server/index.js",
+    "test": "node --test"
+  }
+}

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,160 @@
+import http from 'node:http';
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applyPasteFlags } from './paste-flags.js';
+
+const ROOT_DIR = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '..');
+const PUBLIC_DIR = ROOT_DIR;
+const SCRIPT_TAG = '<script defer src="/assets/js/paste-guard.js"></script>';
+const submissions = [];
+
+function injectPasteGuard(html) {
+  if (html.includes(SCRIPT_TAG)) return html;
+  const closingHead = '</head>';
+  if (html.includes(closingHead)) {
+    return html.replace(closingHead, `  ${SCRIPT_TAG}\n${closingHead}`);
+  }
+  return `${SCRIPT_TAG}\n${html}`;
+}
+
+function getMimeType(filePath) {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+    case '.htm':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.gif':
+      return 'image/gif';
+    case '.svg':
+      return 'image/svg+xml';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function readStaticFile(resolvedPath) {
+  const fileStat = await stat(resolvedPath);
+  if (fileStat.isDirectory()) {
+    const indexPath = path.join(resolvedPath, 'index.html');
+    return readStaticFile(indexPath);
+  }
+  const body = await readFile(resolvedPath);
+  return { body, path: resolvedPath };
+}
+
+function safeResolve(requestPath) {
+  const normalized = path.normalize('.' + requestPath);
+  const resolved = path.resolve(PUBLIC_DIR, normalized);
+  if (!resolved.startsWith(PUBLIC_DIR)) {
+    return null;
+  }
+  return resolved;
+}
+
+async function handleGet(req, res, url) {
+  const pathname = url.pathname === '/' ? '/index.html' : url.pathname;
+  const resolved = safeResolve(pathname);
+  if (!resolved) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+  try {
+    const { body, path: filePath } = await readStaticFile(resolved);
+    const mime = getMimeType(filePath);
+    if (mime.startsWith('text/html')) {
+      const injected = injectPasteGuard(body.toString('utf8'));
+      res.writeHead(200, { 'Content-Type': mime });
+      if (req.method === 'HEAD') {
+        res.end();
+      } else {
+        res.end(injected);
+      }
+    } else {
+      res.writeHead(200, { 'Content-Type': mime });
+      if (req.method === 'HEAD') {
+        res.end();
+      } else {
+        res.end(body);
+      }
+    }
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+    } else {
+      res.writeHead(500, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Server Error');
+    }
+  }
+}
+
+function parseBody(raw, contentType) {
+  if (!raw) return new Map();
+  if (!contentType) return new Map();
+  if (contentType.startsWith('application/json')) {
+    try {
+      const data = JSON.parse(raw || '{}');
+      return new Map(Object.entries(data));
+    } catch {
+      return new Map();
+    }
+  }
+  if (contentType.startsWith('application/x-www-form-urlencoded')) {
+    const params = new URLSearchParams(raw);
+    return new Map(params.entries());
+  }
+  return new Map();
+}
+
+async function handlePost(req, res, url) {
+  if (url.pathname !== '/submissions') {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+    res.end('Not Found');
+    return;
+  }
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+  const raw = Buffer.concat(chunks).toString('utf8');
+  const contentType = req.headers['content-type'] || '';
+  const entries = parseBody(raw, contentType);
+  const { data, flags, attempted } = applyPasteFlags(entries);
+  const record = { data, flags, attempted, receivedAt: new Date().toISOString() };
+  submissions.push(record);
+  res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
+  res.end(JSON.stringify(record));
+}
+
+export function createServer() {
+  const server = http.createServer(async (req, res) => {
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    if (req.method === 'GET' || req.method === 'HEAD') {
+      await handleGet(req, res, url);
+      return;
+    }
+    if (req.method === 'POST') {
+      await handlePost(req, res, url);
+      return;
+    }
+    res.writeHead(405, { 'Allow': 'GET, HEAD, POST' });
+    res.end();
+  });
+  server.submissions = submissions;
+  return server;
+}
+
+export { submissions };

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,7 @@
+import { createServer } from './app.js';
+
+const port = Number(process.env.PORT) || 3000;
+const server = createServer();
+server.listen(port, () => {
+  console.log(`Paste Guard server listening on http://localhost:${port}`);
+});

--- a/server/paste-flags.js
+++ b/server/paste-flags.js
@@ -1,0 +1,34 @@
+export function normalizeEntries(input) {
+  if (!input) return new Map();
+  if (input instanceof Map) return new Map(input);
+  if (Array.isArray(input)) return new Map(input);
+  if (typeof input[Symbol.iterator] === 'function') {
+    return new Map(input);
+  }
+  if (typeof input === 'object') {
+    return new Map(Object.entries(input));
+  }
+  return new Map();
+}
+
+export function applyPasteFlags(input) {
+  const entries = normalizeEntries(input);
+  const data = {};
+  const flags = {};
+  const attempted = [];
+
+  for (const [key, value] of entries) {
+    if (key.endsWith('__cp')) continue;
+    data[key] = value;
+    const flagKey = key + '__cp';
+    const flagged = entries.has(flagKey) && entries.get(flagKey) !== '';
+    if (flagged) {
+      flags[key] = '[CP]';
+      attempted.push(key);
+    } else {
+      flags[key] = '';
+    }
+  }
+
+  return { data, flags, attempted };
+}

--- a/tests/backend.test.js
+++ b/tests/backend.test.js
@@ -1,0 +1,22 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyPasteFlags } from '../server/paste-flags.js';
+
+test('applyPasteFlags marks attempted fields with [CP]', () => {
+  const { data, flags, attempted } = applyPasteFlags([
+    ['answer', 'typed'],
+    ['answer__cp', '1'],
+    ['notes', 'hello'],
+  ]);
+  assert.deepEqual(data, { answer: 'typed', notes: 'hello' });
+  assert.equal(flags.answer, '[CP]');
+  assert.equal(flags.notes, '');
+  assert.deepEqual(attempted, ['answer']);
+});
+
+test('applyPasteFlags ignores cp markers without source field', () => {
+  const { data, flags, attempted } = applyPasteFlags({ 'ghost__cp': '1', user: 'sam' });
+  assert.deepEqual(data, { user: 'sam' });
+  assert.equal(flags.user, '');
+  assert.deepEqual(attempted, []);
+});

--- a/tests/helpers/fake-dom.js
+++ b/tests/helpers/fake-dom.js
@@ -1,0 +1,245 @@
+import { readFileSync } from 'node:fs';
+import { runInNewContext } from 'node:vm';
+
+class FakeNode {
+  constructor() {
+    this.parentNode = null;
+    this.childNodes = [];
+    this.ownerDocument = null;
+  }
+
+  appendChild(child) {
+    child.parentNode = this;
+    child.ownerDocument = this.ownerDocument;
+    this.childNodes.push(child);
+    if (this.tagName === 'FORM') {
+      propagateForm(child, this);
+    } else if (this.form && child instanceof FakeElement && !child.form) {
+      propagateForm(child, this.form);
+    }
+    return child;
+  }
+}
+
+function propagateForm(node, form) {
+  if (!(node instanceof FakeElement)) return;
+  node.form = form;
+  for (const child of node.childNodes) {
+    propagateForm(child, form);
+  }
+}
+
+class FakeElement extends FakeNode {
+  constructor(tagName) {
+    super();
+    this.tagName = String(tagName || '').toUpperCase();
+    this.attributes = new Map();
+    this.style = {};
+    this.classList = new Set();
+    this.textContent = '';
+    this.name = '';
+    this.type = this.tagName === 'INPUT' ? 'text' : undefined;
+    this.form = null;
+    this.value = '';
+  }
+
+  get className() {
+    return Array.from(this.classList).join(' ');
+  }
+
+  set className(value) {
+    this.setAttribute('class', value);
+  }
+
+  setAttribute(name, value = '') {
+    const key = name.toLowerCase();
+    this.attributes.set(key, String(value));
+    if (key === 'class') {
+      this.classList = new Set(String(value).split(/\s+/).filter(Boolean));
+    } else if (key === 'name') {
+      this.name = String(value);
+    } else if (key === 'type') {
+      this.type = String(value).toLowerCase();
+    } else if (key === 'readonly') {
+      this.readOnly = true;
+    } else if (key === 'disabled') {
+      this.disabled = true;
+    }
+  }
+
+  getAttribute(name) {
+    const key = name.toLowerCase();
+    if (!this.attributes.has(key)) return null;
+    return this.attributes.get(key);
+  }
+
+  hasAttribute(name) {
+    return this.attributes.has(name.toLowerCase());
+  }
+
+  insertAdjacentElement(position, element) {
+    if (position !== 'afterend') {
+      throw new Error('Only afterend supported in fake DOM');
+    }
+    const parent = this.parentNode;
+    if (!parent) throw new Error('Element has no parent');
+    const siblings = parent.childNodes;
+    const index = siblings.indexOf(this);
+    element.parentNode = parent;
+    element.ownerDocument = this.ownerDocument;
+    siblings.splice(index + 1, 0, element);
+    if (parent.tagName === 'FORM') {
+      propagateForm(element, parent);
+    } else if (parent.form) {
+      propagateForm(element, parent.form);
+    }
+    return element;
+  }
+
+  get nextSibling() {
+    if (!this.parentNode) return null;
+    const siblings = this.parentNode.childNodes;
+    const index = siblings.indexOf(this);
+    return siblings[index + 1] || null;
+  }
+
+  matches(selector) {
+    return matchesSelector(this, selector);
+  }
+}
+
+class FakeDocument extends FakeNode {
+  constructor() {
+    super();
+    this.ownerDocument = this;
+    this.documentElement = new FakeElement('html');
+    this.documentElement.ownerDocument = this;
+    this.body = new FakeElement('body');
+    this.body.ownerDocument = this;
+    this.documentElement.appendChild(this.body);
+    this._listeners = new Map();
+  }
+
+  createElement(tagName) {
+    const el = new FakeElement(tagName);
+    el.ownerDocument = this;
+    return el;
+  }
+
+  addEventListener(type, handler) {
+    const list = this._listeners.get(type) || [];
+    list.push(handler);
+    this._listeners.set(type, list);
+  }
+
+  getListeners(type) {
+    return this._listeners.get(type) || [];
+  }
+
+  resetListeners() {
+    this._listeners.clear();
+  }
+}
+
+function matchesSelector(element, selector) {
+  if (!selector) return false;
+  return selector.split(',').some(sel => matchSingle(element, sel.trim()));
+}
+
+function matchSingle(element, selector) {
+  if (!selector) return false;
+  const parts = selector.match(/(^[a-z]+)|\[[^\]]+\]|\.[^\.\[]+/gi) || [];
+  let tag = null;
+  const attributes = [];
+  const classes = [];
+  for (const part of parts) {
+    if (part.startsWith('[')) {
+      const attr = part.slice(1, -1);
+      const [rawName, rawValue] = attr.split('=');
+      const name = rawName.trim().toLowerCase();
+      if (rawValue === undefined) {
+        attributes.push({ name, value: null });
+      } else {
+        const value = rawValue.replace(/^"|"$/g, '').replace(/^'|'$/g, '');
+        attributes.push({ name, value });
+      }
+    } else if (part.startsWith('.')) {
+      classes.push(part.slice(1));
+    } else {
+      tag = part.toLowerCase();
+    }
+  }
+  if (tag && element.tagName.toLowerCase() !== tag) return false;
+  for (const cls of classes) {
+    if (!element.classList.has(cls)) return false;
+  }
+  for (const attr of attributes) {
+    if (attr.value === null) {
+      if (!element.hasAttribute(attr.name)) return false;
+    } else {
+      const val = element.getAttribute(attr.name);
+      if (val === null) return false;
+      if (String(val) !== attr.value) return false;
+    }
+  }
+  return true;
+}
+
+function createEventTarget(document, type, target, init) {
+  const event = {
+    type,
+    target,
+    defaultPrevented: false,
+    preventDefault() {
+      this.defaultPrevented = true;
+    }
+  };
+  return Object.assign(event, init || {});
+}
+
+export function createTestEnvironment(config = {}) {
+  const document = new FakeDocument();
+  const window = {
+    document,
+    setTimeout,
+    clearTimeout,
+    PASTE_GUARD_CONFIG: config,
+    PASTE_GUARD_ALLOW_SELECTOR: config.allowSelector || ''
+  };
+  window.window = window;
+  window.HTMLElement = FakeElement;
+  document.defaultView = window;
+
+  const context = {
+    window,
+    document,
+    HTMLElement: FakeElement,
+    setTimeout,
+    clearTimeout
+  };
+  context.self = window;
+  context.globalThis = window;
+
+  const script = readFileSync(new URL('../../assets/js/paste-guard.js', import.meta.url), 'utf8');
+  runInNewContext(script, context, { filename: 'paste-guard.js' });
+
+  function trigger(type, target, init) {
+    const event = createEventTarget(document, type, target, init);
+    for (const handler of document.getListeners(type)) {
+      handler.call(document, event);
+    }
+    return event;
+  }
+
+  return {
+    document,
+    window,
+    trigger,
+    createElement: (...args) => document.createElement(...args),
+    destroy() {
+      document.resetListeners();
+    }
+  };
+}
+
+export { FakeElement };

--- a/tests/paste-guard.test.js
+++ b/tests/paste-guard.test.js
@@ -1,0 +1,109 @@
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { createTestEnvironment, FakeElement } from './helpers/fake-dom.js';
+
+let env;
+
+beforeEach(() => {
+  env = createTestEnvironment();
+});
+
+afterEach(() => {
+  env?.destroy();
+  env = null;
+});
+
+function buildFormField(name, type = 'text') {
+  const form = env.createElement('form');
+  const input = env.createElement('input');
+  input.setAttribute('type', type);
+  input.setAttribute('name', name);
+  form.appendChild(input);
+  env.document.body.appendChild(form);
+  return { form, input };
+}
+
+test('blocks paste events and flags the field', () => {
+  const { form, input } = buildFormField('essay');
+  const event = env.trigger('paste', input);
+  assert.equal(event.defaultPrevented, true, 'paste should be prevented');
+  const hidden = form.childNodes.find(node => node instanceof FakeElement && node.type === 'hidden');
+  assert(hidden, 'hidden cp flag should be appended');
+  assert.equal(hidden.name, 'essay__cp');
+  assert.equal(hidden.value, '1');
+  const warning = input.nextSibling;
+  assert(warning, 'warning element should exist');
+  assert.equal(warning.classList.has('pg-warning'), true);
+  assert.equal(warning.textContent, 'Pasting is disabled here. Please type your answer.');
+  assert.equal(warning.style.display, 'block');
+});
+
+test('drop attempts are blocked and flagged', () => {
+  const { form, input } = buildFormField('notes');
+  const event = env.trigger('drop', input);
+  assert.equal(event.defaultPrevented, true, 'drop should be prevented');
+  const hidden = form.childNodes.find(node => node instanceof FakeElement && node.type === 'hidden');
+  assert(hidden, 'hidden cp flag should be appended for drop');
+});
+
+test('keyboard paste shortcuts are blocked', () => {
+  const { input } = buildFormField('answer');
+  const event = env.trigger('keydown', input, { key: 'v', ctrlKey: true, metaKey: false, shiftKey: false });
+  assert.equal(event.defaultPrevented, true, 'Ctrl+V should be prevented');
+});
+
+test('allowlist selector skips guarded behaviour', () => {
+  env.destroy();
+  env = createTestEnvironment({ allowSelector: 'input[name="allowed"]' });
+  const allowedForm = env.createElement('form');
+  const allowed = env.createElement('input');
+  allowed.setAttribute('type', 'text');
+  allowed.setAttribute('name', 'allowed');
+  allowedForm.appendChild(allowed);
+  env.document.body.appendChild(allowedForm);
+
+  const blockedForm = env.createElement('form');
+  const blocked = env.createElement('input');
+  blocked.setAttribute('type', 'text');
+  blocked.setAttribute('name', 'blocked');
+  blockedForm.appendChild(blocked);
+  env.document.body.appendChild(blockedForm);
+
+  const allowedEvent = env.trigger('paste', allowed);
+  assert.equal(allowedEvent.defaultPrevented, false, 'allowlisted field should permit paste');
+  const blockedEvent = env.trigger('paste', blocked);
+  assert.equal(blockedEvent.defaultPrevented, true, 'non-allowlisted field should be blocked');
+  const hidden = blockedForm.childNodes.find(node => node instanceof FakeElement && node.type === 'hidden');
+  assert(hidden, 'blocked field should receive cp flag');
+});
+
+test('hidden cp fields are only added to attempted inputs', () => {
+  const form = env.createElement('form');
+  const typed = env.createElement('input');
+  typed.setAttribute('type', 'text');
+  typed.setAttribute('name', 'typed');
+  const pasted = env.createElement('input');
+  pasted.setAttribute('type', 'text');
+  pasted.setAttribute('name', 'pasted');
+  form.appendChild(typed);
+  form.appendChild(pasted);
+  env.document.body.appendChild(form);
+
+  env.trigger('paste', pasted);
+
+  const names = form.childNodes
+    .filter(node => node instanceof FakeElement && node.name)
+    .map(node => node.name);
+  assert.deepEqual(names.sort(), ['pasted', 'pasted__cp', 'typed']);
+});
+
+test('warning automatically hides after configured duration', async () => {
+  env.destroy();
+  env = createTestEnvironment({ warnDuration: 10 });
+  const { input } = buildFormField('autoHide');
+  env.trigger('paste', input);
+  const warning = input.nextSibling;
+  assert.equal(warning.style.display, 'block');
+  await new Promise(resolve => setTimeout(resolve, 25));
+  assert.equal(warning.style.display, 'none');
+});

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,41 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createServer } from '../server/app.js';
+
+async function withServer(fn) {
+  const server = createServer();
+  await new Promise(resolve => server.listen(0, resolve));
+  const { port } = server.address();
+  try {
+    await fn(port, server);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+test('server injects paste guard script into html responses', async () => {
+  await withServer(async port => {
+    const res = await fetch(`http://127.0.0.1:${port}/index.html`);
+    assert.equal(res.ok, true);
+    const html = await res.text();
+    assert(html.includes('<script defer src="/assets/js/paste-guard.js"></script>'));
+  });
+});
+
+test('server captures cp flags on submission', async () => {
+  await withServer(async (port, server) => {
+    const body = 'answer=typed&answer__cp=1&notes=manual';
+    const res = await fetch(`http://127.0.0.1:${port}/submissions`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    assert.equal(res.ok, true);
+    const payload = await res.json();
+    assert.deepEqual(payload.data, { answer: 'typed', notes: 'manual' });
+    assert.equal(payload.flags.answer, '[CP]');
+    assert.equal(payload.flags.notes, '');
+    assert.deepEqual(payload.attempted, ['answer']);
+    assert.equal(server.submissions.length > 0, true);
+  });
+});


### PR DESCRIPTION
## Summary
- add a global Paste Guard script that blocks paste/drop combos, shows warnings, and flags [CP] attempts with hidden inputs
- introduce a lightweight Node server that injects the guard into every HTML response and normalises CP markers for submissions
- add automated tests with a fake DOM harness plus server coverage, update the README with usage instructions, and replace the embedded demo GIF with a text-based walkthrough that can link to externally hosted media

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cfe0e8d0bc8331a2eaac19b859a265