### PR TITLE
Fix general progress bar fill behavior

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -961,3 +961,16 @@ footer {
     padding: 10px 20px !important;
   }
 }
+/* === Progress bar: filled portion is green; width driven by JS === */
+.general-progress-bar {
+  position: relative;              /* ensures inner fill lays out correctly */
+  overflow: hidden;                /* clip rounded corners if any */
+}
+
+.general-progress-fill {
+  background: #10b981 !important;  /* solid green */
+  background-image: none !important;
+  transition: width 300ms ease;    /* smooth change when updated */
+  height: 100%;
+  border-radius: inherit;          /* keep rounded corners if parent has them */
+}

--- a/a/dashboard.js
+++ b/a/dashboard.js
@@ -25,22 +25,24 @@ async function updateGeneralProgress() {
 
   const total = totalPoints + totalLevels;
   const done = points + levels;
-  const percent = total ? Math.round((done / total) * 100) : 0;
+  const percent = total ? (done / total) * 100 : 0;
+  const roundedPercent = Math.round(percent);
+  const clampedPercent = Math.max(0, Math.min(100, percent));
 
-  fill.style.width = percent + "%";
-  fill.textContent = percent + "%";
+  fill.textContent = roundedPercent + "%";
+  fill.style.setProperty("width", clampedPercent + "%", "important");
 
   fill.classList.remove("progress-low", "progress-medium", "progress-high");
 
   let progressClass = "progress-low";
-  if (percent >= 67) {
+  if (roundedPercent >= 67) {
     progressClass = "progress-high";
-  } else if (percent >= 34) {
+  } else if (roundedPercent >= 34) {
     progressClass = "progress-medium";
   }
 
   fill.classList.add(progressClass);
-  console.debug('[dashboard] Progress percent', percent);
+  console.debug('[dashboard] Progress percent', roundedPercent);
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -946,3 +946,17 @@ footer {
     padding: 10px 20px !important;
   }
 }
+
+/* === Progress bar: filled portion is green; width driven by JS === */
+.general-progress-bar {
+  position: relative;              /* ensures inner fill lays out correctly */
+  overflow: hidden;                /* clip rounded corners if any */
+}
+
+.general-progress-fill {
+  background: #10b981 !important;  /* solid green */
+  background-image: none !important;
+  transition: width 300ms ease;    /* smooth change when updated */
+  height: 100%;
+  border-radius: inherit;          /* keep rounded corners if parent has them */
+}

--- a/as/dashboard.js
+++ b/as/dashboard.js
@@ -25,11 +25,13 @@ async function updateGeneralProgress() {
 
   const total = totalPoints + totalLevels;
   const done = points + levels;
-  const percent = total ? Math.round((done / total) * 100) : 0;
+  const percent = total ? (done / total) * 100 : 0;
+  const roundedPercent = Math.round(percent);
+  const clampedPercent = Math.max(0, Math.min(100, percent));
 
-  fill.style.width = percent + "%";
-  fill.textContent = percent + "%";
-  console.debug('[dashboard] Progress percent', percent);
+  fill.textContent = roundedPercent + "%";
+  fill.style.setProperty("width", clampedPercent + "%", "important");
+  console.debug('[dashboard] Progress percent', roundedPercent);
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -946,3 +946,17 @@ footer {
     padding: 10px 20px !important;
   }
 }
+
+/* === Progress bar: filled portion is green; width driven by JS === */
+.general-progress-bar {
+  position: relative;              /* ensures inner fill lays out correctly */
+  overflow: hidden;                /* clip rounded corners if any */
+}
+
+.general-progress-fill {
+  background: #10b981 !important;  /* solid green */
+  background-image: none !important;
+  transition: width 300ms ease;    /* smooth change when updated */
+  height: 100%;
+  border-radius: inherit;          /* keep rounded corners if parent has them */
+}

--- a/igcse/dashboard.js
+++ b/igcse/dashboard.js
@@ -25,11 +25,13 @@ async function updateGeneralProgress() {
 
   const total = totalPoints + totalLevels;
   const done = points + levels;
-  const percent = total ? Math.round((done / total) * 100) : 0;
+  const percent = total ? (done / total) * 100 : 0;
+  const roundedPercent = Math.round(percent);
+  const clampedPercent = Math.max(0, Math.min(100, percent));
 
-  fill.style.width = percent + "%";
-  fill.textContent = percent + "%";
-  console.debug('[dashboard] Progress percent', percent);
+  fill.textContent = roundedPercent + "%";
+  fill.style.setProperty("width", clampedPercent + "%", "important");
+  console.debug('[dashboard] Progress percent', roundedPercent);
 }
 
 document.addEventListener("DOMContentLoaded", () => {


### PR DESCRIPTION
## Summary
- clamp and apply progress percentage widths via inline styles so the general progress bar fill matches the computed value
- keep the displayed percentage text in sync while preserving progress state classes
- enforce a consistent green progress fill with smooth transitions across dashboards via CSS overrides

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68cfe9efcc0883319e10bcd7c4a16658