### PR TITLE
Automate paste guard injection for static HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -10,6 +10,7 @@
     h1 { font-size: 48px; color: #cc0000; }
     p { font-size: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <h1>404</h1>

--- a/a-level/computer-science-9618/index.html
+++ b/a-level/computer-science-9618/index.html
@@ -19,6 +19,7 @@
     a {text-decoration: underline;}
     .card {border: 1px solid #ddd; padding: 12px; border-radius: 6px; margin-top: 12px;}
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <nav aria-label="Breadcrumb">

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Computer Science Journey</title>
   <link rel="stylesheet" href="./dashboard.css"/>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/exercises1.html
+++ b/a/levels/exercises1.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../exercises.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/exercises2.html
+++ b/a/levels/exercises2.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../exercises.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/exercises3.html
+++ b/a/levels/exercises3.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../exercises.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/exercises4.html
+++ b/a/levels/exercises4.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../exercises.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/exercises5.html
+++ b/a/levels/exercises5.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../exercises.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/level1.html
+++ b/a/levels/level1.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Level 1: Overview and Setup</title>
   <link rel="stylesheet" href="../levels.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/level2.html
+++ b/a/levels/level2.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Level 2: Basic I/O and Operators</title>
   <link rel="stylesheet" href="../levels.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/level3.html
+++ b/a/levels/level3.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Level 3: Selection with if, else, elif</title>
   <link rel="stylesheet" href="../levels.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/level4.html
+++ b/a/levels/level4.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Level 4: Loops and Control Flow</title>
   <link rel="stylesheet" href="../levels.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/levels/level5.html
+++ b/a/levels/level5.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Level 5: Working with Lists</title>
   <link rel="stylesheet" href="../levels.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/a/points/13.1/doc.html
+++ b/a/points/13.1/doc.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>IGCSE Computer Science - 13.1 User-defined data types</title>
     <link href="../igcse-style.css" rel="stylesheet" />
+  <script defer src="/assets/js/paste-guard.js"></script>
   </head>
   <body>
     <div class="container">

--- a/a/points/13.1/layer1.html
+++ b/a/points/13.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.1/layer2.html
+++ b/a/points/13.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.1/layer3.html
+++ b/a/points/13.1/layer3.html
@@ -150,6 +150,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.1/layer4.html
+++ b/a/points/13.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.2/doc.html
+++ b/a/points/13.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 13.2 File organisation and access</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/a/points/13.2/layer1.html
+++ b/a/points/13.2/layer1.html
@@ -221,6 +221,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.2/layer2.html
+++ b/a/points/13.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.2/layer3.html
+++ b/a/points/13.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.2/layer4.html
+++ b/a/points/13.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.3/doc.html
+++ b/a/points/13.3/doc.html
@@ -219,6 +219,7 @@
             margin: 15px 0;
         }
     </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
     <div class="container">

--- a/a/points/13.3/layer1.html
+++ b/a/points/13.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.3/layer2.html
+++ b/a/points/13.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.3/layer3.html
+++ b/a/points/13.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/13.3/layer4.html
+++ b/a/points/13.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.1/doc.html
+++ b/a/points/14.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/14.1/layer1.html
+++ b/a/points/14.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.1/layer2.html
+++ b/a/points/14.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.1/layer3.html
+++ b/a/points/14.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.1/layer4.html
+++ b/a/points/14.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.2/doc.html
+++ b/a/points/14.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/14.2/layer1.html
+++ b/a/points/14.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.2/layer2.html
+++ b/a/points/14.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.2/layer3.html
+++ b/a/points/14.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/14.2/layer4.html
+++ b/a/points/14.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.1/doc.html
+++ b/a/points/15.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/15.1/layer1.html
+++ b/a/points/15.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.1/layer2.html
+++ b/a/points/15.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.1/layer3.html
+++ b/a/points/15.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.1/layer4.html
+++ b/a/points/15.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.2/doc.html
+++ b/a/points/15.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/15.2/layer1.html
+++ b/a/points/15.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.2/layer2.html
+++ b/a/points/15.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.2/layer3.html
+++ b/a/points/15.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/15.2/layer4.html
+++ b/a/points/15.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.1/doc.html
+++ b/a/points/16.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/16.1/layer1.html
+++ b/a/points/16.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.1/layer2.html
+++ b/a/points/16.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.1/layer3.html
+++ b/a/points/16.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.1/layer4.html
+++ b/a/points/16.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.2/doc.html
+++ b/a/points/16.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/16.2/layer1.html
+++ b/a/points/16.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.2/layer2.html
+++ b/a/points/16.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.2/layer3.html
+++ b/a/points/16.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/16.2/layer4.html
+++ b/a/points/16.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/17/doc.html
+++ b/a/points/17/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/17/layer1.html
+++ b/a/points/17/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/17/layer2.html
+++ b/a/points/17/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/17/layer3.html
+++ b/a/points/17/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/17/layer4.html
+++ b/a/points/17/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/18/doc.html
+++ b/a/points/18/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/18/layer1.html
+++ b/a/points/18/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/18/layer2.html
+++ b/a/points/18/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/18/layer3.html
+++ b/a/points/18/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/18/layer4.html
+++ b/a/points/18/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.1/doc.html
+++ b/a/points/19.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/19.1/layer1.html
+++ b/a/points/19.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.1/layer2.html
+++ b/a/points/19.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.1/layer3.html
+++ b/a/points/19.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.1/layer4.html
+++ b/a/points/19.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.2/doc.html
+++ b/a/points/19.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/19.2/layer1.html
+++ b/a/points/19.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.2/layer2.html
+++ b/a/points/19.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.2/layer3.html
+++ b/a/points/19.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/19.2/layer4.html
+++ b/a/points/19.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.1/doc.html
+++ b/a/points/20.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/20.1/layer1.html
+++ b/a/points/20.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.1/layer2.html
+++ b/a/points/20.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.1/layer3.html
+++ b/a/points/20.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.1/layer4.html
+++ b/a/points/20.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.2/doc.html
+++ b/a/points/20.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Content not ready</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/a/points/20.2/layer1.html
+++ b/a/points/20.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.2/layer2.html
+++ b/a/points/20.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.2/layer3.html
+++ b/a/points/20.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/a/points/20.2/layer4.html
+++ b/a/points/20.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as-level/computer-science-9618/index.html
+++ b/as-level/computer-science-9618/index.html
@@ -19,6 +19,7 @@
     a {text-decoration: underline;}
     .card {border: 1px solid #ddd; padding: 12px; border-radius: 6px; margin-top: 12px;}
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <nav aria-label="Breadcrumb">

--- a/as/dashboard.html
+++ b/as/dashboard.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Computer Science Journey</title>
   <link rel="stylesheet" href="./dashboard.css"/>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/as/levels/level1.html
+++ b/as/levels/level1.html
@@ -39,6 +39,7 @@
       color: #f0f0f0;
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header class="level-header">

--- a/as/levels/level10.html
+++ b/as/levels/level10.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 10</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level11.html
+++ b/as/levels/level11.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 11</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level12.html
+++ b/as/levels/level12.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 12</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level13.html
+++ b/as/levels/level13.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 13</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level14.html
+++ b/as/levels/level14.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 14</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level15.html
+++ b/as/levels/level15.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 15</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level16.html
+++ b/as/levels/level16.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 16</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level2.html
+++ b/as/levels/level2.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 2</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level3.html
+++ b/as/levels/level3.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 3</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level4.html
+++ b/as/levels/level4.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 4</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level5.html
+++ b/as/levels/level5.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 5</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level6.html
+++ b/as/levels/level6.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 6</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level7.html
+++ b/as/levels/level7.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 7</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level8.html
+++ b/as/levels/level8.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 8</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/levels/level9.html
+++ b/as/levels/level9.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 9</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/as/points/1.1/doc.html
+++ b/as/points/1.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/1.1/layer1.html
+++ b/as/points/1.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.1/layer2.html
+++ b/as/points/1.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.1/layer3.html
+++ b/as/points/1.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.1/layer4.html
+++ b/as/points/1.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.2/doc.html
+++ b/as/points/1.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/1.2/layer1.html
+++ b/as/points/1.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.2/layer2.html
+++ b/as/points/1.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.2/layer3.html
+++ b/as/points/1.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.2/layer4.html
+++ b/as/points/1.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.3/doc.html
+++ b/as/points/1.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/1.3/layer1.html
+++ b/as/points/1.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.3/layer2.html
+++ b/as/points/1.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.3/layer3.html
+++ b/as/points/1.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/1.3/layer4.html
+++ b/as/points/1.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/2/doc.html
+++ b/as/points/2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/2/layer1.html
+++ b/as/points/2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/2/layer2.html
+++ b/as/points/2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/2/layer3.html
+++ b/as/points/2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/2/layer4.html
+++ b/as/points/2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.1/doc.html
+++ b/as/points/3.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/3.1/layer1.html
+++ b/as/points/3.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.1/layer2.html
+++ b/as/points/3.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.1/layer3.html
+++ b/as/points/3.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.1/layer4.html
+++ b/as/points/3.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.2/doc.html
+++ b/as/points/3.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/3.2/layer1.html
+++ b/as/points/3.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.2/layer2.html
+++ b/as/points/3.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.2/layer3.html
+++ b/as/points/3.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/3.2/layer4.html
+++ b/as/points/3.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.1/doc.html
+++ b/as/points/4.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/4.1/layer1.html
+++ b/as/points/4.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.1/layer2.html
+++ b/as/points/4.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.1/layer3.html
+++ b/as/points/4.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.1/layer4.html
+++ b/as/points/4.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.2/doc.html
+++ b/as/points/4.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/4.2/layer1.html
+++ b/as/points/4.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.2/layer2.html
+++ b/as/points/4.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.2/layer3.html
+++ b/as/points/4.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.2/layer4.html
+++ b/as/points/4.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.3/doc.html
+++ b/as/points/4.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/4.3/layer1.html
+++ b/as/points/4.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.3/layer2.html
+++ b/as/points/4.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.3/layer3.html
+++ b/as/points/4.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/4.3/layer4.html
+++ b/as/points/4.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/5/doc.html
+++ b/as/points/5/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/5/layer1.html
+++ b/as/points/5/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/5/layer2.html
+++ b/as/points/5/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/5/layer3.html
+++ b/as/points/5/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/5/layer4.html
+++ b/as/points/5/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/6/doc.html
+++ b/as/points/6/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/6/layer1.html
+++ b/as/points/6/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/6/layer2.html
+++ b/as/points/6/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/6/layer3.html
+++ b/as/points/6/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/6/layer4.html
+++ b/as/points/6/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/7/doc.html
+++ b/as/points/7/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/7/layer1.html
+++ b/as/points/7/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/7/layer2.html
+++ b/as/points/7/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/7/layer3.html
+++ b/as/points/7/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/7/layer4.html
+++ b/as/points/7/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.1/doc.html
+++ b/as/points/8.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/8.1/layer1.html
+++ b/as/points/8.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.1/layer2.html
+++ b/as/points/8.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.1/layer3.html
+++ b/as/points/8.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.1/layer4.html
+++ b/as/points/8.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.2/doc.html
+++ b/as/points/8.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/8.2/layer1.html
+++ b/as/points/8.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.2/layer2.html
+++ b/as/points/8.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.2/layer3.html
+++ b/as/points/8.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.2/layer4.html
+++ b/as/points/8.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.3/doc.html
+++ b/as/points/8.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>1.1 Number Systems</title>
   <link rel="stylesheet" href="igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
    <div class="container">

--- a/as/points/8.3/layer1.html
+++ b/as/points/8.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.3/layer2.html
+++ b/as/points/8.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.3/layer3.html
+++ b/as/points/8.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/as/points/8.3/layer4.html
+++ b/as/points/8.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -7,6 +7,7 @@
   <meta name="description" content="IGCSE Computer Science 0478 resources on hamdeni-cs.tn.">
   <link rel="canonical" href="https://hamdeni-cs.tn/igcse/dashboard.html">
   <link rel="stylesheet" href="./dashboard.css"/>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/levels/level1.html
+++ b/igcse/levels/level1.html
@@ -39,6 +39,7 @@
       color: #f0f0f0;
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header class="level-header">

--- a/igcse/levels/level10.html
+++ b/igcse/levels/level10.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 10</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level11.html
+++ b/igcse/levels/level11.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 11</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level12.html
+++ b/igcse/levels/level12.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 12</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level13.html
+++ b/igcse/levels/level13.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 13</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level14.html
+++ b/igcse/levels/level14.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 14</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level15.html
+++ b/igcse/levels/level15.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 15</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level16.html
+++ b/igcse/levels/level16.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 16</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level2.html
+++ b/igcse/levels/level2.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 2</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level3.html
+++ b/igcse/levels/level3.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 3</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level4.html
+++ b/igcse/levels/level4.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 4</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level5.html
+++ b/igcse/levels/level5.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 5</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level6.html
+++ b/igcse/levels/level6.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 6</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level7.html
+++ b/igcse/levels/level7.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 7</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level8.html
+++ b/igcse/levels/level8.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 8</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/levels/level9.html
+++ b/igcse/levels/level9.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Level 9</title>
   <link rel="stylesheet" href="../dashboard.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header style="text-align:center;padding:20px;background:#003366;color:#fff;">

--- a/igcse/points/1.1/doc.html
+++ b/igcse/points/1.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 1.1: Number systems</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/1.1/layer1.html
+++ b/igcse/points/1.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.1/layer2.html
+++ b/igcse/points/1.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.1/layer3.html
+++ b/igcse/points/1.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.1/layer4.html
+++ b/igcse/points/1.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.2/doc.html
+++ b/igcse/points/1.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 1.2 Text, Sound and Images</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/igcse/points/1.2/layer1.html
+++ b/igcse/points/1.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.2/layer2.html
+++ b/igcse/points/1.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.2/layer3.html
+++ b/igcse/points/1.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.2/layer4.html
+++ b/igcse/points/1.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.3/doc.html
+++ b/igcse/points/1.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 1.3 Data storage and compression</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/1.3/layer1.html
+++ b/igcse/points/1.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.3/layer2.html
+++ b/igcse/points/1.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.3/layer3.html
+++ b/igcse/points/1.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/1.3/layer4.html
+++ b/igcse/points/1.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.1/doc.html
+++ b/igcse/points/2.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 2.1 Types and methods of data transmission</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/2.1/layer1.html
+++ b/igcse/points/2.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.1/layer2.html
+++ b/igcse/points/2.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.1/layer3.html
+++ b/igcse/points/2.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.1/layer4.html
+++ b/igcse/points/2.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.2/doc.html
+++ b/igcse/points/2.2/doc.html
@@ -3,6 +3,7 @@
 <head>
   <title>IGCSE Computer Science: 2.2 Methods of error detection</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/2.2/layer1.html
+++ b/igcse/points/2.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.2/layer2.html
+++ b/igcse/points/2.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.2/layer3.html
+++ b/igcse/points/2.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.2/layer4.html
+++ b/igcse/points/2.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.3/doc.html
+++ b/igcse/points/2.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 2.3 Encryption</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/2.3/layer1.html
+++ b/igcse/points/2.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.3/layer2.html
+++ b/igcse/points/2.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.3/layer3.html
+++ b/igcse/points/2.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/2.3/layer4.html
+++ b/igcse/points/2.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.1/doc.html
+++ b/igcse/points/3.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 3.2 Input and Output Devices</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <!-- Bullet count check: JSON bullets = 137; HTML <li> = 137; verified = True -->

--- a/igcse/points/3.1/layer1.html
+++ b/igcse/points/3.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.1/layer2.html
+++ b/igcse/points/3.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.1/layer3.html
+++ b/igcse/points/3.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.1/layer4.html
+++ b/igcse/points/3.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.2/doc.html
+++ b/igcse/points/3.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 3.2 Input and Output Devices</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <!-- Bullet count check: JSON bullets = 137; HTML <li> = 137; verified = True -->

--- a/igcse/points/3.2/layer1.html
+++ b/igcse/points/3.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.2/layer2.html
+++ b/igcse/points/3.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.2/layer3.html
+++ b/igcse/points/3.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.2/layer4.html
+++ b/igcse/points/3.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.3/doc.html
+++ b/igcse/points/3.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 3.3 Data Storage</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/3.3/layer1.html
+++ b/igcse/points/3.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.3/layer2.html
+++ b/igcse/points/3.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.3/layer3.html
+++ b/igcse/points/3.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.3/layer4.html
+++ b/igcse/points/3.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.4/doc.html
+++ b/igcse/points/3.4/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 3.4 Network hardware</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/3.4/layer1.html
+++ b/igcse/points/3.4/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.4/layer2.html
+++ b/igcse/points/3.4/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.4/layer3.html
+++ b/igcse/points/3.4/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/3.4/layer4.html
+++ b/igcse/points/3.4/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.1/doc.html
+++ b/igcse/points/4.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 4.1 Hardware and Software</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/4.1/layer1.html
+++ b/igcse/points/4.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.1/layer2.html
+++ b/igcse/points/4.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.1/layer3.html
+++ b/igcse/points/4.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.1/layer4.html
+++ b/igcse/points/4.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.2/doc.html
+++ b/igcse/points/4.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 4.2 Programming Concepts</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/4.2/layer1.html
+++ b/igcse/points/4.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.2/layer2.html
+++ b/igcse/points/4.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.2/layer3.html
+++ b/igcse/points/4.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/4.2/layer4.html
+++ b/igcse/points/4.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.1/doc.html
+++ b/igcse/points/5.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 5.1 The internet and the WWW</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/5.1/layer1.html
+++ b/igcse/points/5.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.1/layer2.html
+++ b/igcse/points/5.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.1/layer3.html
+++ b/igcse/points/5.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.1/layer4.html
+++ b/igcse/points/5.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.2/doc.html
+++ b/igcse/points/5.2/doc.html
@@ -5,6 +5,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 5.2 Digital Currency</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/igcse/points/5.2/layer1.html
+++ b/igcse/points/5.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.2/layer2.html
+++ b/igcse/points/5.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.2/layer3.html
+++ b/igcse/points/5.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.2/layer4.html
+++ b/igcse/points/5.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.3/doc.html
+++ b/igcse/points/5.3/doc.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <title>IGCSE Computer Science - 5.3 Cyber Security</title>
 <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/igcse/points/5.3/layer1.html
+++ b/igcse/points/5.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.3/layer2.html
+++ b/igcse/points/5.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.3/layer3.html
+++ b/igcse/points/5.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/5.3/layer4.html
+++ b/igcse/points/5.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.1/doc.html
+++ b/igcse/points/6.1/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 6.1 Automated Systems</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/igcse/points/6.1/layer1.html
+++ b/igcse/points/6.1/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.1/layer2.html
+++ b/igcse/points/6.1/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.1/layer3.html
+++ b/igcse/points/6.1/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.1/layer4.html
+++ b/igcse/points/6.1/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.2/doc.html
+++ b/igcse/points/6.2/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 6.2 Robotics</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 <div class="container">

--- a/igcse/points/6.2/layer1.html
+++ b/igcse/points/6.2/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.2/layer2.html
+++ b/igcse/points/6.2/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.2/layer3.html
+++ b/igcse/points/6.2/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.2/layer4.html
+++ b/igcse/points/6.2/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.3/doc.html
+++ b/igcse/points/6.3/doc.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>IGCSE Computer Science - 6.3 Artificial Intelligence</title>
   <link rel="stylesheet" href="../igcse-style.css">
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/igcse/points/6.3/layer1.html
+++ b/igcse/points/6.3/layer1.html
@@ -220,6 +220,7 @@
     }
 
 </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.3/layer2.html
+++ b/igcse/points/6.3/layer2.html
@@ -243,6 +243,7 @@
 
   </style>
 
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.3/layer3.html
+++ b/igcse/points/6.3/layer3.html
@@ -148,6 +148,7 @@
       box-shadow: 0 4px 16px rgba(102, 59, 15, 0.12);
     }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/igcse/points/6.3/layer4.html
+++ b/igcse/points/6.3/layer4.html
@@ -96,6 +96,7 @@
     }
     #ready-message { margin-top: 20px; }
   </style>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Computer Science with Dr. Hamdeni</title>
   <link rel="stylesheet" href="css/style.css" />
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "private": true,
   "scripts": {
     "start": "node server/index.js",
-    "test": "node --test"
+    "test": "node --test",
+    "inject:paste-guard": "node scripts/inject-paste-guard.mjs",
+    "predeploy": "node scripts/inject-paste-guard.mjs"
   }
 }

--- a/scripts/inject-paste-guard.mjs
+++ b/scripts/inject-paste-guard.mjs
@@ -1,0 +1,71 @@
+import { readdir, readFile, writeFile } from 'fs/promises';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(SCRIPT_DIR, '..');
+const TARGET_TAG = '<script defer src="/assets/js/paste-guard.js"></script>';
+const HEAD_CLOSE_REGEX = /([ \t]*)<\/head\s*>/i;
+const IGNORED_DIRS = new Set(['node_modules', '.git', 'tests']);
+
+async function collectHtmlFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (IGNORED_DIRS.has(entry.name)) continue;
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectHtmlFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.html')) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+async function injectIntoFile(filePath) {
+  const original = await readFile(filePath, 'utf8');
+  if (original.includes(TARGET_TAG)) {
+    return false;
+  }
+
+  const match = original.match(HEAD_CLOSE_REGEX);
+  if (!match) {
+    return false;
+  }
+
+  const indent = match[1] ?? '';
+  const injection = `${indent}${TARGET_TAG}\n${indent}</head>`;
+  const updated = original.replace(HEAD_CLOSE_REGEX, injection);
+  if (updated === original) {
+    return false;
+  }
+
+  await writeFile(filePath, updated, 'utf8');
+  return true;
+}
+
+async function main() {
+  const htmlFiles = await collectHtmlFiles(ROOT_DIR);
+  const modified = [];
+  for (const file of htmlFiles) {
+    const didModify = await injectIntoFile(file);
+    if (didModify) {
+      modified.push(path.relative(ROOT_DIR, file));
+    }
+  }
+
+  if (modified.length) {
+    console.log('Injected paste guard script into:');
+    for (const file of modified) {
+      console.log(` - ${file}`);
+    }
+  } else {
+    console.log('No files required paste guard injection.');
+  }
+}
+
+main().catch(error => {
+  console.error('Failed to inject paste guard script:', error);
+  process.exitCode = 1;
+});

--- a/teacher/teacher-dashboard.html
+++ b/teacher/teacher-dashboard.html
@@ -6,6 +6,7 @@
   <title>Teacher Dashboard</title>
   <link rel="stylesheet" href="teacher.css" />
   <script type="module" src="teacher.js"></script>
+<script defer src="/assets/js/paste-guard.js"></script>
 </head>
 <body>
   <header>


### PR DESCRIPTION
## Summary
- add a reusable injection script that adds the paste guard tag to every HTML file before deployment
- wire the injector into npm scripts and run it to embed the guard script across the static site

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cff8588e2c8331b56be2cbc3b71d02