### PR TITLE
Update IGCSE level links to notes pages

### DIFF
--- a/igcse/modules/levelRenderer.js
+++ b/igcse/modules/levelRenderer.js
@@ -66,7 +66,9 @@ export async function renderProgrammingLevels() {
         if (box.classList.contains("locked")) {
           alert("This level is locked.");
         } else {
-          window.location.href = `./levels/level${index + 1}.html`;
+          const levelFolder = `Level ${index + 1}`;
+          const encodedFolder = encodeURIComponent(levelFolder);
+          window.location.href = `./levels/${encodedFolder}/notes.html`;
         }
       } catch (err) {
         console.error('[levelRenderer] Level box click error:', err);


### PR DESCRIPTION
## Summary
- update IGCSE level renderer to open the new per-level notes.html files inside each Level folder
- encode the folder name so that spaces in the Level directories resolve correctly when navigating

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cffde156dc8331831c533db8a584ec