### PR TITLE
Add Term 1 grade indicator to A Level dashboard

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -140,6 +140,7 @@ body {
   box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15) !important;
   position: relative !important;
   overflow: hidden !important;
+  flex-wrap: wrap !important;
 }
 
 .header-background + .header-row .general-progress-wrapper::before {
@@ -246,6 +247,34 @@ body {
   line-height: 14px !important;
   font-weight: 600 !important;
   text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8) !important;
+}
+
+.header-background + .header-row .term-grade-badge {
+  display: flex !important;
+  flex-direction: column !important;
+  gap: 4px !important;
+  padding: 10px 14px !important;
+  border-radius: 12px !important;
+  background: rgba(102, 126, 234, 0.12) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.12) !important;
+  position: relative !important;
+  z-index: 1 !important;
+}
+
+.header-background + .header-row .term-grade-label {
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 1px !important;
+  color: #4c63d2 !important;
+  text-transform: uppercase !important;
+}
+
+.header-background + .header-row .term-grade-value {
+  font-size: 20px !important;
+  font-weight: 800 !important;
+  color: #1f2937 !important;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6) !important;
 }
 
 /* Target ONLY form box in the specific header-row after header-background */

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -27,6 +27,10 @@
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>
         </div>
+        <div class="term-grade-badge">
+          <span class="term-grade-label">TERM 1 GRADE</span>
+          <span id="term-grade-value" class="term-grade-value">0</span>
+        </div>
     </div>
   </div>
 

--- a/a/dashboard.js
+++ b/a/dashboard.js
@@ -5,6 +5,7 @@ import { initializeLogin, fetchProgressCounts, verifyPlatform } from "./modules/
 
 async function updateGeneralProgress() {
   const fill = document.querySelector(".general-progress-fill");
+  const termGradeEl = document.getElementById("term-grade-value");
   if (!fill) return;
   console.log('[dashboard] Updating general progress');
 
@@ -21,7 +22,12 @@ async function updateGeneralProgress() {
 
   const totalLevels = 16; // defined in levelRenderer
 
-  const { points, levels } = await fetchProgressCounts();
+  const { points, levels, term1Grade } = await fetchProgressCounts();
+
+  if (termGradeEl) {
+    const gradeValue = Math.max(0, Number(term1Grade) || 0);
+    termGradeEl.textContent = gradeValue.toString();
+  }
 
   const total = totalPoints + totalLevels;
   const done = points + levels;

--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -33,7 +33,7 @@ export async function fetchProgressCounts() {
   const username = localStorage.getItem('username');
   const platform = localStorage.getItem('platform');
 
-  if (!username || !platform) return { points: 0, levels: 0 };
+  if (!username || !platform) return { points: 0, levels: 0, term1Grade: 0 };
 
   const theoryTable = tableName(platform, 'theory');
   const levelTable = tableName(platform, 'programming');
@@ -58,19 +58,30 @@ export async function fetchProgressCounts() {
     const tData = await tRes.json();
     const lData = await lRes.json();
 
-    const passedPoints = tData.filter(r => r.reached_layer === '4').length;
+    const passedPoints = tData.filter(r => String(r.reached_layer) === '4').length;
+    const term1Grade = tData.reduce((total, record) => {
+      const reachedLayer = Number(record.reached_layer);
+      if (!Number.isFinite(reachedLayer)) return total;
+
+      let increment = 0;
+      if (reachedLayer >= 1) increment += 1;
+      if (reachedLayer >= 2) increment += 2;
+      if (reachedLayer >= 3) increment += 3;
+      if (reachedLayer >= 4) increment += 4;
+      return total + increment;
+    }, 0);
     let passedLevels = 0;
     if (platform === 'A_Level') {
       passedLevels = lData.length ? lData[0].reached_level : 0;
     } else {
       passedLevels = lData.filter(r => r.level_done).length;
     }
-    const result = { points: passedPoints, levels: passedLevels };
+    const result = { points: passedPoints, levels: passedLevels, term1Grade };
     console.log('[supabaseModule] Progress counts', result);
     return result;
   } catch (err) {
     console.error('❌ Failed fetching progress counts:', err);
-    return { points: 0, levels: 0 };
+    return { points: 0, levels: 0, term1Grade: 0 };
   }
 }
 


### PR DESCRIPTION
## Summary
- add a Term 1 grade badge next to the general progress bar on the A Level dashboard
- style the badge and progress wrapper so the new grade display fits the existing header layout
- compute the Term 1 grade from Supabase layer progress data and surface it in the dashboard UI

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d05851824c833191915e5f0087d0e9