### PR TITLE
Center IGCSE level cards text

### DIFF
--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -750,10 +750,11 @@ body {
   cursor: pointer;
   position: relative;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 8px;
-  text-align: left;
+  gap: 6px;
+  text-align: center;
 }
 
 .level-box:hover {
@@ -774,11 +775,15 @@ body {
 }
 
 .level-icon {
-  font-size: 1.2em;
+  font-size: 1.4em;
 }
 
 .level-text {
-  line-height: 1.2;
+  line-height: 1.3;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
 }
 
 .arrow-img {


### PR DESCRIPTION
## Summary
- stack the level icon and text so the entire card content is centered
- center the level copy and tweak spacing to keep the layout balanced

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d0712064a48331abdd5c239dfbe483