### PR TITLE
Adjust level card spacing on IGCSE dashboard

### DIFF
--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -783,7 +783,16 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 0;
+}
+
+.level-text .level-number,
+.level-text .level-title {
+  display: block;
+}
+
+.level-text .level-number {
+  font-weight: 700;
 }
 
 .arrow-img {

--- a/igcse/modules/levelRenderer.js
+++ b/igcse/modules/levelRenderer.js
@@ -61,8 +61,8 @@ export async function renderProgrammingLevels() {
     box.innerHTML = `
       <span class="level-icon">${icon}</span>
       <div class="level-text">
-        <strong>Level ${displayNumber}</strong><br/>
-        <span>${level.title}</span>
+        <strong class="level-number">Level ${displayNumber}</strong>
+        <span class="level-title">${level.title}</span>
       </div>
     `;
     box.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- render the programming level number and title in separate blocks
- remove the extra gap inside level cards so the title sits directly beneath the level number

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0826cda08833184f0a056aaa4198b