### PR TITLE
Center level dashboard text

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -797,7 +797,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  text-align: left;
+  text-align: center;
 }
 
 .level-box:hover {
@@ -823,6 +823,10 @@ body {
 
 .level-text {
   line-height: 1.2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .arrow-img {

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -753,7 +753,7 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  text-align: left;
+  text-align: center;
 }
 
 .level-box:hover {
@@ -779,6 +779,10 @@ body {
 
 .level-text {
   line-height: 1.2;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
 }
 
 .arrow-img {

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -783,6 +783,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
+  text-align: center;
   gap: 4px;
 }
 


### PR DESCRIPTION
## Summary
- center the contents of level boxes on the advanced, AS, and IGCSE dashboards
- update level text styling to stack lines and align them centrally within each box

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0822a7c648331a57e8c4f2ad5d12f