### PR TITLE
Improve term grade badge layout

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -35,9 +35,9 @@ body {
   border-radius: 16px !important;
   box-shadow: 0 15px 35px rgba(0, 0, 0, 0.08) !important;
   position: relative !important;
-  overflow: hidden !important;
+  overflow: visible !important;
   margin: 15px !important;
-  max-height: 150px !important;
+  max-height: none !important;
 }
 
 /* Animated gradient border - ONLY for the specific header-row */
@@ -128,10 +128,11 @@ body {
 
 /* Target ONLY progress wrapper in the specific header-row after header-background */
 .header-background + .header-row .general-progress-wrapper {
-  display: flex !important;
+  display: grid !important;
+  grid-template-columns: auto minmax(0, 1fr) auto !important;
   align-items: center !important;
-  gap: 18px !important;
-  justify-content: flex-start !important;
+  gap: 12px 18px !important;
+  justify-content: stretch !important;
   background: rgba(255, 255, 255, 0.95) !important;
   backdrop-filter: blur(15px) !important;
   padding: 18px 24px !important;
@@ -139,8 +140,7 @@ body {
   border: 2px solid rgba(102, 126, 234, 0.2) !important;
   box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15) !important;
   position: relative !important;
-  overflow: hidden !important;
-  flex-wrap: wrap !important;
+  overflow: visible !important;
 }
 
 .header-background + .header-row .general-progress-wrapper::before {
@@ -161,6 +161,7 @@ body {
 }
 
 .header-background + .header-row .general-progress-label {
+  grid-column: 1 / 2 !important;
   font-weight: 800 !important;
   font-size: 13px !important;
   letter-spacing: 1.2px !important;
@@ -173,14 +174,15 @@ body {
 }
 
 .header-background + .header-row .general-progress-bar {
-  flex-grow: 1 !important;
+  grid-column: 2 / 3 !important;
+  width: 100% !important;
   height: 14px !important;
   background: #e2e8f0 !important;
   border-radius: 50px !important;
   position: relative !important;
   overflow: hidden !important;
   box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.15) !important;
-  min-width: 320px !important;
+  min-width: clamp(200px, 35vw, 320px) !important;
   border: 1px solid rgba(102, 126, 234, 0.2) !important;
 }
 
@@ -250,31 +252,97 @@ body {
 }
 
 .header-background + .header-row .term-grade-badge {
+  grid-column: 3 / 4 !important;
+  justify-self: end !important;
   display: flex !important;
   flex-direction: column !important;
-  gap: 4px !important;
-  padding: 10px 14px !important;
-  border-radius: 12px !important;
-  background: rgba(102, 126, 234, 0.12) !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 6px !important;
+  padding: 14px 18px !important;
+  min-width: 132px !important;
+  border-radius: 18px !important;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.18) 0%, rgba(118, 75, 162, 0.22) 100%) !important;
   border: 1px solid rgba(102, 126, 234, 0.35) !important;
-  box-shadow: 0 4px 12px rgba(102, 126, 234, 0.12) !important;
+  box-shadow: 0 10px 25px rgba(102, 126, 234, 0.18) !important;
   position: relative !important;
-  z-index: 1 !important;
+  overflow: hidden !important;
+  isolation: isolate !important;
+  transition: transform 0.3s ease, box-shadow 0.3s ease !important;
+}
+
+.header-background + .header-row .term-grade-badge::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.7), transparent 60%) !important;
+  opacity: 0.85;
+  z-index: 0;
+}
+
+.header-background + .header-row .term-grade-badge:hover {
+  transform: translateY(-2px) !important;
+  box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;
 }
 
 .header-background + .header-row .term-grade-label {
+  position: relative !important;
+  z-index: 1 !important;
   font-size: 11px !important;
   font-weight: 700 !important;
   letter-spacing: 1px !important;
   color: #4c63d2 !important;
   text-transform: uppercase !important;
+  opacity: 0.85 !important;
 }
 
 .header-background + .header-row .term-grade-value {
-  font-size: 20px !important;
+  position: relative !important;
+  z-index: 1 !important;
+  font-size: 24px !important;
   font-weight: 800 !important;
-  color: #1f2937 !important;
-  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.6) !important;
+  color: #1b254b !important;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.65) !important;
+  line-height: 1.1 !important;
+}
+
+@media (max-width: 820px) {
+  .header-background + .header-row .general-progress-wrapper {
+    grid-template-columns: 1fr !important;
+  }
+
+  .header-background + .header-row .general-progress-label,
+  .header-background + .header-row .general-progress-bar,
+  .header-background + .header-row .term-grade-badge {
+    grid-column: 1 / -1 !important;
+  }
+
+  .header-background + .header-row .term-grade-badge {
+    justify-self: stretch !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    text-align: left !important;
+    gap: 12px !important;
+    padding: 16px 20px !important;
+  }
+
+  .header-background + .header-row .general-progress-label {
+    white-space: normal !important;
+  }
+
+  .header-background + .header-row .term-grade-badge::before {
+    background: radial-gradient(circle at 95% 10%, rgba(255, 255, 255, 0.75), transparent 65%) !important;
+  }
+
+  .header-background + .header-row .term-grade-label {
+    font-size: 10px !important;
+    letter-spacing: 0.8px !important;
+  }
+
+  .header-background + .header-row .term-grade-value {
+    font-size: 22px !important;
+  }
 }
 
 /* Target ONLY form box in the specific header-row after header-background */

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -29,7 +29,7 @@
         </div>
         <div class="term-grade-badge">
           <span class="term-grade-label">TERM 1 GRADE</span>
-          <span id="term-grade-value" class="term-grade-value">0</span>
+          <span id="term-grade-value" class="term-grade-value">0%</span>
         </div>
     </div>
   </div>

--- a/a/dashboard.js
+++ b/a/dashboard.js
@@ -25,8 +25,15 @@ async function updateGeneralProgress() {
   const { points, levels, term1Grade } = await fetchProgressCounts();
 
   if (termGradeEl) {
-    const gradeValue = Math.max(0, Number(term1Grade) || 0);
-    termGradeEl.textContent = gradeValue.toString();
+    const numericGrade = Number(term1Grade);
+    const sanitizedGrade = Number.isFinite(numericGrade)
+      ? Math.min(100, Math.max(0, numericGrade))
+      : 0;
+    const formattedGrade = Number.isInteger(sanitizedGrade)
+      ? sanitizedGrade.toString()
+      : sanitizedGrade.toFixed(1);
+
+    termGradeEl.textContent = `${formattedGrade}%`;
   }
 
   const total = totalPoints + totalLevels;


### PR DESCRIPTION
## Summary
- switch the general progress strip to a responsive grid so the Term 1 grade badge fits cleanly within its parent
- refresh the badge styling with a gradient background, hover state, and mobile-friendly alignment
- sanitize the fetched Term 1 grade and display it with a percentage suffix, including the default markup

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d081e4a67483319825182c45226a06