### PR TITLE
Adjust level card layout

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -631,27 +631,43 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 10px;
+  gap: 16px;
 }
 
 .level-box {
   background: #e0e0e0;
-  width: 50%;
-  padding: 10px;
-  border-radius: 10px;
+  width: min(100%, 340px);
+  padding: 16px 18px;
+  border-radius: 12px;
   text-align: center;
   position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.level-box h4 {
-  margin: 0;
-  font-size: 1.1em;
+.level-box .level-line {
+  display: block;
+  width: 100%;
 }
 
-.level-box p {
-  margin: 5px 0 0;
-  font-size: 0.85em;
-  color: #333;
+.level-box .level-status {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.level-box .level-number {
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: 0.02em;
+}
+
+.level-box .level-title {
+  font-size: 0.9rem;
+  line-height: 1.35;
 }
 
 .level-box.locked {

--- a/a/modules/levelRenderer.js
+++ b/a/modules/levelRenderer.js
@@ -40,14 +40,26 @@ export async function renderProgrammingLevels() {
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);
     const box = document.createElement("div");
+    const levelNumber = index + 1;
     let status = 'locked';
-    if (index + 1 < reached) {
+    if (levelNumber < reached) {
       status = 'passed';
-    } else if (index + 1 === reached) {
+    } else if (levelNumber === reached) {
       status = 'unlocked';
     }
     box.className = `level-box ${status}`;
-    box.dataset.level = index + 1;
+    box.dataset.level = levelNumber;
+
+    const statusLabels = {
+      locked: "Locked",
+      unlocked: "Unlocked",
+      passed: "Completed"
+    };
+    const statusLabel = statusLabels[status] ?? status;
+    box.setAttribute(
+      "aria-label",
+      `${statusLabel} Level ${levelNumber}: ${level.title}`
+    );
 
     let icon = "";
     if (status === "locked") icon = "\uD83D\uDD12"; // 🔒
@@ -55,11 +67,9 @@ export async function renderProgrammingLevels() {
     else if (status === "passed") icon = "\u2705"; // ✅
 
     box.innerHTML = `
-      <span class="level-icon">${icon}</span>
-      <div class="level-text">
-        <strong>Level ${index + 1}</strong><br/>
-        <span>${level.title}</span>
-      </div>
+      <div class="level-line level-status" aria-hidden="true">${icon}</div>
+      <div class="level-line level-number">Level ${levelNumber}</div>
+      <div class="level-line level-title">${level.title}</div>
     `;
     box.addEventListener("click", () => {
       try {


### PR DESCRIPTION
## Summary
- render programming levels with explicit three-line layout for the status icon, level label, and level title
- add semantic labelling for level cards to improve accessibility
- refresh dashboard level card styles to support the new stacked presentation

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0859c84a08331aca24aba7383e945