### PR TITLE
Fix Layer 2 quiz point id resolution

### DIFF
--- a/a/points/13.1/quiz.js
+++ b/a/points/13.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/13.2/quiz.js
+++ b/a/points/13.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/13.3/quiz.js
+++ b/a/points/13.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/14.1/quiz.js
+++ b/a/points/14.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/14.2/quiz.js
+++ b/a/points/14.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/15.1/quiz.js
+++ b/a/points/15.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/15.2/quiz.js
+++ b/a/points/15.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/16.1/quiz.js
+++ b/a/points/16.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/16.2/quiz.js
+++ b/a/points/16.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/17/quiz.js
+++ b/a/points/17/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/18/quiz.js
+++ b/a/points/18/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/19.1/quiz.js
+++ b/a/points/19.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/19.2/quiz.js
+++ b/a/points/19.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/20.1/quiz.js
+++ b/a/points/20.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/a/points/20.2/quiz.js
+++ b/a/points/20.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/1.1/quiz.js
+++ b/as/points/1.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/1.2/quiz.js
+++ b/as/points/1.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/1.3/quiz.js
+++ b/as/points/1.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/2/quiz.js
+++ b/as/points/2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/3.1/quiz.js
+++ b/as/points/3.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/3.2/quiz.js
+++ b/as/points/3.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/4.1/quiz.js
+++ b/as/points/4.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/4.2/quiz.js
+++ b/as/points/4.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/4.3/quiz.js
+++ b/as/points/4.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/5/quiz.js
+++ b/as/points/5/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/6/quiz.js
+++ b/as/points/6/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/7/quiz.js
+++ b/as/points/7/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/8.1/quiz.js
+++ b/as/points/8.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/8.2/quiz.js
+++ b/as/points/8.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/as/points/8.3/quiz.js
+++ b/as/points/8.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/1.1/quiz.js
+++ b/igcse/points/1.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/1.2/quiz.js
+++ b/igcse/points/1.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/1.3/quiz.js
+++ b/igcse/points/1.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/2.1/quiz.js
+++ b/igcse/points/2.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/2.2/quiz.js
+++ b/igcse/points/2.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/2.3/quiz.js
+++ b/igcse/points/2.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/3.1/quiz.js
+++ b/igcse/points/3.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/3.2/quiz.js
+++ b/igcse/points/3.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/3.3/quiz.js
+++ b/igcse/points/3.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/3.4/quiz.js
+++ b/igcse/points/3.4/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/4.1/quiz.js
+++ b/igcse/points/4.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/4.2/quiz.js
+++ b/igcse/points/4.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/5.1/quiz.js
+++ b/igcse/points/5.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/5.2/quiz.js
+++ b/igcse/points/5.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/5.3/quiz.js
+++ b/igcse/points/5.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/6.1/quiz.js
+++ b/igcse/points/6.1/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/6.2/quiz.js
+++ b/igcse/points/6.2/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',

--- a/igcse/points/6.3/quiz.js
+++ b/igcse/points/6.3/quiz.js
@@ -6,10 +6,18 @@ const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZ
 const supabase = window.supabase;
 const username = localStorage.getItem("username");
 const platform = localStorage.getItem("platform");
-const pointId = (location.pathname
-  .split("/")
-  .find(p => /^p\d+$/i.test(p)) || "")
-  .toLowerCase();
+const pointId = (() => {
+  if (typeof point_id !== 'undefined' && point_id) {
+    return String(point_id).trim();
+  }
+
+  const segment = location.pathname
+    .split('/')
+    .filter(Boolean)
+    .find(part => /^\d+(?:\.\d+)?$/.test(part));
+
+  return segment || '';
+})().toLowerCase();
 
 const PROGRESS_TABLES = {
   A_Level: 'a_theory_progress',


### PR DESCRIPTION
## Summary
- update every Layer 2 quiz script to resolve `pointId` from the injected `point_id` value or the actual folder segment that matches the numeric point pattern
- ensure the Supabase lookups and upserts now use the real point identifier so prior progress can be read and new progress is written to the correct record

## Testing
- npm test
- node - <<'NODE' ... (simulation verifying `point_id` "13.1" is used for the select and upsert)


------
https://chatgpt.com/codex/tasks/task_e_68d1d8529ce48331a0f3f30c36ae058e