### PR TITLE
Avoid platform name collisions on layer2 pages

### DIFF
--- a/a/points/13.1/layer2.html
+++ b/a/points/13.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "13.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/13.2/layer2.html
+++ b/a/points/13.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "13.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/13.3/layer2.html
+++ b/a/points/13.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "13.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/14.1/layer2.html
+++ b/a/points/14.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "14.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/14.2/layer2.html
+++ b/a/points/14.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "14.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/15.1/layer2.html
+++ b/a/points/15.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "15.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/15.2/layer2.html
+++ b/a/points/15.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "15.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/16.1/layer2.html
+++ b/a/points/16.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "16.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/16.2/layer2.html
+++ b/a/points/16.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "16.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/17/layer2.html
+++ b/a/points/17/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "17";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/18/layer2.html
+++ b/a/points/18/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "18";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/19.1/layer2.html
+++ b/a/points/19.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "19.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/19.2/layer2.html
+++ b/a/points/19.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "19.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/20.1/layer2.html
+++ b/a/points/20.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "20.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/a/points/20.2/layer2.html
+++ b/a/points/20.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "20.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/1.1/layer2.html
+++ b/as/points/1.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/1.2/layer2.html
+++ b/as/points/1.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/1.3/layer2.html
+++ b/as/points/1.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/2/layer2.html
+++ b/as/points/2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/3.1/layer2.html
+++ b/as/points/3.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/3.2/layer2.html
+++ b/as/points/3.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/4.1/layer2.html
+++ b/as/points/4.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "4.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/4.2/layer2.html
+++ b/as/points/4.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "4.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/4.3/layer2.html
+++ b/as/points/4.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "4.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/5/layer2.html
+++ b/as/points/5/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "5";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/6/layer2.html
+++ b/as/points/6/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "6";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/7/layer2.html
+++ b/as/points/7/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "7";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/8.1/layer2.html
+++ b/as/points/8.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "8.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/8.2/layer2.html
+++ b/as/points/8.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "8.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/as/points/8.3/layer2.html
+++ b/as/points/8.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "8.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/1.1/layer2.html
+++ b/igcse/points/1.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/1.2/layer2.html
+++ b/igcse/points/1.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/1.3/layer2.html
+++ b/igcse/points/1.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "1.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/2.1/layer2.html
+++ b/igcse/points/2.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "2.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/2.2/layer2.html
+++ b/igcse/points/2.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "2.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/2.3/layer2.html
+++ b/igcse/points/2.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "2.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/3.1/layer2.html
+++ b/igcse/points/3.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/3.2/layer2.html
+++ b/igcse/points/3.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/3.3/layer2.html
+++ b/igcse/points/3.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/3.4/layer2.html
+++ b/igcse/points/3.4/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "3.4";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/4.1/layer2.html
+++ b/igcse/points/4.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "4.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/4.2/layer2.html
+++ b/igcse/points/4.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "4.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/5.1/layer2.html
+++ b/igcse/points/5.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "5.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/5.2/layer2.html
+++ b/igcse/points/5.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "5.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/5.3/layer2.html
+++ b/igcse/points/5.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "5.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/6.1/layer2.html
+++ b/igcse/points/6.1/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "6.1";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/6.2/layer2.html
+++ b/igcse/points/6.2/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "6.2";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;

--- a/igcse/points/6.3/layer2.html
+++ b/igcse/points/6.3/layer2.html
@@ -287,15 +287,15 @@
 
   <script>
     const student_name = localStorage.getItem("student_name");
-    const platform = localStorage.getItem("platform");
+    const layerPlatform = localStorage.getItem("platform");
     const point_id = "6.3";
 
     if (student_name) {
       document.getElementById("student-name").textContent = "👤 " + student_name;
     }
 
-    if (platform) {
-      document.getElementById("platform-name").textContent = "🎓 Platform: " + platform;
+    if (layerPlatform) {
+      document.getElementById("platform-name").textContent = "🎓 Platform: " + layerPlatform;
     }
 
     document.getElementById("point-title").textContent = point_id;


### PR DESCRIPTION
## Summary
- rename the inline Layer 2 `platform` constant to `layerPlatform` across the a/as/igcse point pages so it does not conflict with quiz.js
- keep the DOM updates in sync with the new identifier so the platform name still renders for students

## Testing
- npm start (manually loaded http://127.0.0.1:3000/a/points/15.2/layer2.html)

------
https://chatgpt.com/codex/tasks/task_e_68d1dd28b8c883319bc1ad15505e02e4