### PR TITLE
Adjust term scoring weights

### DIFF
--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -29,10 +29,11 @@ function tableName(platform, type) {
 }
 
 const LAYER_WEIGHTS = Object.freeze({
+  0: 0,
   1: 1,
-  2: 2,
-  3: 3,
-  4: 4
+  2: 3,
+  3: 6,
+  4: 10
 });
 
 function weightForLayer(value) {


### PR DESCRIPTION
## Summary
- align Term 1 grade calculation with the specified rubric
- update layer weights so 0/1/2/3/4 green bars award 0/1/3/6/10 points respectively

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5262255948331a7e767995d3a73de