### PR TITLE
Update progress label for Cambridge exam readiness

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -162,15 +162,20 @@ body {
 
 .header-background + .header-row .general-progress-label {
   grid-column: 1 / 2 !important;
+  display: block !important;
   font-weight: 800 !important;
-  font-size: 13px !important;
-  letter-spacing: 1.2px !important;
+  font-size: 12px !important;
+  letter-spacing: 0.8px !important;
   color: #4c63d2 !important;
   text-transform: uppercase !important;
-  white-space: nowrap !important;
+  white-space: normal !important;
+  line-height: 1.35 !important;
+  max-width: clamp(160px, 24vw, 240px) !important;
+  text-align: left !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
   z-index: 1 !important;
   position: relative !important;
+  align-self: start !important;
 }
 
 .header-background + .header-row .general-progress-bar {

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -22,7 +22,7 @@
       <div id="student-name-bar" style="font-weight: bold; font-size: 1.2em;">Guest Mode</div>
     </div>
     <div class="general-progress-wrapper">
-      <div class="general-progress-label">GENERAL PROGRESS</div>
+      <div class="general-progress-label">Cambridge Exam Readiness Progress</div>
         <div class="general-progress-bar">
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>

--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -160,12 +160,16 @@ body {
 }
 
 .header-background + .header-row .general-progress-label {
+  display: block !important;
   font-weight: 800 !important;
-  font-size: 13px !important;
-  letter-spacing: 1.2px !important;
+  font-size: 12px !important;
+  letter-spacing: 0.8px !important;
   color: #4c63d2 !important;
   text-transform: uppercase !important;
-  white-space: nowrap !important;
+  white-space: normal !important;
+  line-height: 1.35 !important;
+  max-width: clamp(160px, 24vw, 240px) !important;
+  text-align: left !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
   z-index: 1 !important;
   position: relative !important;

--- a/as/dashboard.html
+++ b/as/dashboard.html
@@ -22,7 +22,7 @@
       <div id="student-name-bar" style="font-weight: bold; font-size: 1.2em;">Guest Mode</div>
     </div>
     <div class="general-progress-wrapper">
-      <div class="general-progress-label">GENERAL PROGRESS</div>
+      <div class="general-progress-label">Cambridge Exam Readiness Progress</div>
         <div class="general-progress-bar">
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -160,12 +160,16 @@ body {
 }
 
 .header-background + .header-row .general-progress-label {
+  display: block !important;
   font-weight: 800 !important;
-  font-size: 13px !important;
-  letter-spacing: 1.2px !important;
+  font-size: 12px !important;
+  letter-spacing: 0.8px !important;
   color: #4c63d2 !important;
   text-transform: uppercase !important;
-  white-space: nowrap !important;
+  white-space: normal !important;
+  line-height: 1.35 !important;
+  max-width: clamp(160px, 24vw, 240px) !important;
+  text-align: left !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
   z-index: 1 !important;
   position: relative !important;

--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -24,7 +24,7 @@
       <div id="student-name-bar" style="font-weight: bold; font-size: 1.2em;">Guest Mode</div>
     </div>
     <div class="general-progress-wrapper">
-      <div class="general-progress-label">GENERAL PROGRESS</div>
+      <div class="general-progress-label">Cambridge Exam Readiness Progress</div>
         <div class="general-progress-bar">
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>


### PR DESCRIPTION
## Summary
- replace the "GENERAL PROGRESS" label with "Cambridge Exam Readiness Progress" across all three dashboards
- adjust the progress label styling so the longer title wraps cleanly without breaking the layout

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59a3541b48331adcc1f6fecd2914d