### PR TITLE
Update A level branding to replace IGCSE wording

### DIFF
--- a/a/levels/level1.html
+++ b/a/levels/level1.html
@@ -19,7 +19,7 @@
       <!-- Title block moved into the same row -->
       <div class="header-main">
         <h1>Level 1: Overview and Setup</h1>
-        <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+        <p>A level Computer Science (9618): student notes, prepared by Dr. Hamdeni</p>
       </div>
 
       <a class="btn btn-home" href="../dashboard.html">

--- a/a/levels/level2.html
+++ b/a/levels/level2.html
@@ -19,7 +19,7 @@
 
         <div class="header-main">
           <h1>Level 2: Basic I/O and Operators</h1>
-          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+          <p>A level Computer Science (9618): student notes, prepared by Dr. Hamdeni</p>
         </div>
 
         <a class="btn btn-home" href="../dashboard.html">

--- a/a/levels/level3.html
+++ b/a/levels/level3.html
@@ -19,7 +19,7 @@
 
         <div class="header-main">
           <h1>Level 3: Selection with if, else, elif</h1>
-          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+          <p>A level Computer Science (9618): student notes, prepared by Dr. Hamdeni</p>
         </div>
 
         <a class="btn btn-home" href="../dashboard.html">

--- a/a/levels/level4.html
+++ b/a/levels/level4.html
@@ -19,7 +19,7 @@
 
         <div class="header-main">
           <h1>Level 4: Loops and Control Flow</h1>
-          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+          <p>A level Computer Science (9618): student notes, prepared by Dr. Hamdeni</p>
         </div>
 
         <a class="btn btn-home" href="../dashboard.html">

--- a/a/levels/level5.html
+++ b/a/levels/level5.html
@@ -19,7 +19,7 @@
 
         <div class="header-main">
           <h1>Level 5: Working with Lists</h1>
-          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+          <p>A level Computer Science (9618): student notes, prepared by Dr. Hamdeni</p>
         </div>
 
         <a class="btn btn-home" href="../../dashboard.html">

--- a/a/points/13.1/doc.html
+++ b/a/points/13.1/doc.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <title>IGCSE Computer Science - 13.1 User-defined data types</title>
+    <title>A level Computer Science - 13.1 User-defined data types</title>
     <link href="../igcse-style.css" rel="stylesheet" />
   <script defer src="/assets/js/paste-guard.js"></script>
   </head>
@@ -14,7 +14,7 @@
           <h1 class="section-title">13.1 User-defined data types</h1>
         </div>
         <div class="title-underline"></div>
-        <p class="section-subtitle">Computer Science IGCSE notes, prepared by Dr. Hamdeni</p>
+        <p class="section-subtitle">Computer Science A level notes, prepared by Dr. Hamdeni</p>
       </div>
       <div class="section">
         <h2>13.1a: Show understanding of why user-defined types are necessary</h2>

--- a/a/points/13.2/doc.html
+++ b/a/points/13.2/doc.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>IGCSE Computer Science - 13.2 File organisation and access</title>
+  <title>A level Computer Science - 13.2 File organisation and access</title>
   <link rel="stylesheet" href="../igcse-style.css">
 <script defer src="/assets/js/paste-guard.js"></script>
 </head>
@@ -14,7 +14,7 @@
     <h1 class="section-title">13.2 File organisation and access</h1>
   </div>
   <div class="title-underline"></div>
-  <p class="section-subtitle">Computer Science IGCSE notes, prepared by Dr. Hamdeni</p>
+  <p class="section-subtitle">Computer Science A level notes, prepared by Dr. Hamdeni</p>
 </div>
   <div class="section">
     <h2>13.2a. File organization methods</h2>


### PR DESCRIPTION
## Summary
- update the A level level-overview pages so their subtitles reference the A level Computer Science (9618) syllabus
- retitle the A level theory documents for topics 13.1 and 13.2 and adjust their subtitles to say "A level"

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5927f47488331acfeacb3a263c190