### PR TITLE
Add tooltip explaining Term 1 grade calculation

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -285,6 +285,49 @@ body {
   z-index: 0;
 }
 
+.header-background + .header-row .term-grade-tooltip {
+  position: absolute !important;
+  top: calc(100% + 12px) !important;
+  left: 50% !important;
+  transform: translate(-50%, -6px) !important;
+  padding: 10px 16px !important;
+  border-radius: 10px !important;
+  background: rgba(255, 255, 255, 0.98) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 12px 30px rgba(27, 37, 75, 0.18) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  color: #1b254b !important;
+  white-space: nowrap !important;
+  z-index: 10 !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease !important;
+}
+
+.header-background + .header-row .term-grade-tooltip::before {
+  content: '' !important;
+  position: absolute !important;
+  bottom: 100% !important;
+  left: 50% !important;
+  transform: translateX(-50%) rotate(45deg) !important;
+  width: 12px !important;
+  height: 12px !important;
+  background: inherit !important;
+  border-left: 1px solid rgba(102, 126, 234, 0.35) !important;
+  border-top: 1px solid rgba(102, 126, 234, 0.35) !important;
+  transform-origin: center !important;
+  box-shadow: inherit !important;
+}
+
+.header-background + .header-row .term-grade-badge:hover .term-grade-tooltip,
+.header-background + .header-row .term-grade-badge:focus-within .term-grade-tooltip {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: translate(-50%, 0) !important;
+}
+
 .header-background + .header-row .term-grade-badge:hover {
   transform: translateY(-2px) !important;
   box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -27,9 +27,12 @@
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>
         </div>
-        <div class="term-grade-badge">
+        <div class="term-grade-badge" aria-describedby="term-grade-tooltip" tabindex="0">
           <span class="term-grade-label">TERM 1 GRADE</span>
           <span id="term-grade-value" class="term-grade-value">0%</span>
+          <div id="term-grade-tooltip" class="term-grade-tooltip" role="tooltip">
+            Term 1 grade = 1×(Layer 1 passed) + 2×(Layer 2 passed) + 3×(Layer 3 passed) + 4×(Layer 4 passed).
+          </div>
         </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add an accessible tooltip next to the Term 1 grade badge explaining the calculation formula
- style the tooltip to appear on hover/focus while keeping the formula on a single line

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d59e64133c8331b7b61733f4230cc8