### PR TITLE
Add dashboard tooltips for term targets

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -328,6 +328,63 @@ body {
   transform: translate(-50%, 0) !important;
 }
 
+.dashboard .tooltip-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: help;
+  outline: none;
+}
+
+.dashboard .tooltip-container:focus {
+  box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.35);
+  border-radius: 12px;
+}
+
+.dashboard .tooltip-container .image-tooltip {
+  position: absolute;
+  bottom: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 8px);
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(102, 126, 234, 0.35);
+  box-shadow: 0 12px 30px rgba(27, 37, 75, 0.18);
+  font-size: 12px;
+  font-weight: 600;
+  color: #1b254b;
+  text-align: center;
+  white-space: nowrap;
+  z-index: 5;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+}
+
+.dashboard .tooltip-container .image-tooltip::before {
+  content: '';
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  background: inherit;
+  border-right: 1px solid rgba(102, 126, 234, 0.35);
+  border-bottom: 1px solid rgba(102, 126, 234, 0.35);
+}
+
+.dashboard .tooltip-container:hover .image-tooltip,
+.dashboard .tooltip-container:focus .image-tooltip,
+.dashboard .tooltip-container:focus-within .image-tooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translate(-50%, 0);
+}
+
 .header-background + .header-row .term-grade-badge:hover {
   transform: translateY(-2px) !important;
   box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -54,16 +54,22 @@
 <!-- ✅ Main Content -->
 <main class="dashboard">
   <section class="theory-column">
-    <div class="section-header">
+    <div class="section-header tooltip-container" tabindex="0" aria-describedby="advanced-theory-tooltip">
       <img src="./images/advanced_theory.png" alt="Advanced Theory" class="section-title" style="transform: scale(1.3); transform-origin: center;"/>
+      <div id="advanced-theory-tooltip" class="image-tooltip" role="tooltip">
+        Term 1 target: finish 10 syllabus points.
+      </div>
     </div>
     <div id="theory-points" class="theory-wrapper"></div>
     <img src="./images/approved_banner.png" class="footer-image" alt="Approved"/>
   </section>
 
   <section class="levels-column">
-    <div class="section-header">
+    <div class="section-header tooltip-container" tabindex="0" aria-describedby="programming-skills-tooltip">
       <img src="./images/programming_skills.png" alt="Programming Skills" class="section-title"/>
+      <div id="programming-skills-tooltip" class="image-tooltip" role="tooltip">
+        Term 1 target: reach level 12.
+      </div>
     </div>
     <div id="programming-levels" class="levels-wrapper"></div>
     <img src="./images/certificate.png" class="certificate-image" alt="Certificate"/>


### PR DESCRIPTION
## Summary
- add tooltip containers to the Advanced Theory and Programming Skills images on the level dashboard
- style the new tooltips to match the dashboard aesthetic and support hover and focus interactions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5a13f04148331804cc373f6d808ec