### PR TITLE
Add term 1 grade badge to AS and IGCSE dashboards

### DIFF
--- a/as/dashboard.css
+++ b/as/dashboard.css
@@ -128,11 +128,11 @@ body {
 
 /* Target ONLY progress wrapper in the specific header-row after header-background */
 .header-background + .header-row .general-progress-wrapper {
-  display: flex !important;
-  flex-direction: column !important;
-  align-items: flex-start !important;
-  gap: 10px !important;
-  justify-content: flex-start !important;
+  display: grid !important;
+  grid-template-columns: auto minmax(0, 1fr) auto !important;
+  align-items: center !important;
+  gap: 12px 18px !important;
+  justify-content: stretch !important;
   background: rgba(255, 255, 255, 0.95) !important;
   backdrop-filter: blur(15px) !important;
   padding: 18px 24px !important;
@@ -140,7 +140,7 @@ body {
   border: 2px solid rgba(102, 126, 234, 0.2) !important;
   box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15) !important;
   position: relative !important;
-  overflow: hidden !important;
+  overflow: visible !important;
 }
 
 .header-background + .header-row .general-progress-wrapper::before {
@@ -161,30 +161,33 @@ body {
 }
 
 .header-background + .header-row .general-progress-label {
+  grid-column: 1 / 2 !important;
   display: block !important;
   font-weight: 800 !important;
   font-size: 12px !important;
   letter-spacing: 0.8px !important;
   color: #4c63d2 !important;
   text-transform: uppercase !important;
-  white-space: nowrap !important;
+  white-space: normal !important;
   line-height: 1.35 !important;
-  max-width: none !important;
+  max-width: clamp(160px, 24vw, 240px) !important;
   text-align: left !important;
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
   z-index: 1 !important;
   position: relative !important;
+  align-self: start !important;
 }
 
 .header-background + .header-row .general-progress-bar {
-  flex-grow: 1 !important;
+  grid-column: 2 / 3 !important;
+  width: 100% !important;
   height: 14px !important;
   background: #e2e8f0 !important;
   border-radius: 50px !important;
   position: relative !important;
   overflow: hidden !important;
   box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.15) !important;
-  min-width: 320px !important;
+  min-width: clamp(200px, 35vw, 320px) !important;
   border: 1px solid rgba(102, 126, 234, 0.2) !important;
 }
 
@@ -203,6 +206,21 @@ body {
   transition: width 1s cubic-bezier(0.4, 0, 0.2, 1) !important;
   animation: finalHeaderGradientFlow 4s ease infinite !important;
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-low {
+  background: linear-gradient(90deg, #ef4444 0%, #f97316 100%) !important;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-medium {
+  background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%) !important;
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-high {
+  background: linear-gradient(90deg, #10b981 0%, #059669 100%) !important;
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.45) !important;
 }
 
 @keyframes finalHeaderGradientFlow {
@@ -236,6 +254,143 @@ body {
   line-height: 14px !important;
   font-weight: 600 !important;
   text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8) !important;
+}
+
+.header-background + .header-row .term-grade-badge {
+  grid-column: 3 / 4 !important;
+  justify-self: end !important;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 6px !important;
+  padding: 14px 18px !important;
+  min-width: 132px !important;
+  border-radius: 18px !important;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.18) 0%, rgba(118, 75, 162, 0.22) 100%) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 10px 25px rgba(102, 126, 234, 0.18) !important;
+  position: relative !important;
+  overflow: hidden !important;
+  isolation: isolate !important;
+  transition: transform 0.3s ease, box-shadow 0.3s ease !important;
+}
+
+.header-background + .header-row .term-grade-badge::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.7), transparent 60%) !important;
+  opacity: 0.85;
+  z-index: 0;
+}
+
+.header-background + .header-row .term-grade-tooltip {
+  position: absolute !important;
+  top: calc(100% + 12px) !important;
+  left: 50% !important;
+  transform: translate(-50%, -6px) !important;
+  padding: 10px 16px !important;
+  border-radius: 10px !important;
+  background: rgba(255, 255, 255, 0.98) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 12px 30px rgba(27, 37, 75, 0.18) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  color: #1b254b !important;
+  white-space: nowrap !important;
+  z-index: 10 !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease !important;
+}
+
+.header-background + .header-row .term-grade-tooltip::before {
+  content: '' !important;
+  position: absolute !important;
+  bottom: 100% !important;
+  left: 50% !important;
+  transform: translateX(-50%) rotate(45deg) !important;
+  width: 12px !important;
+  height: 12px !important;
+  background: inherit !important;
+  border-left: 1px solid rgba(102, 126, 234, 0.35) !important;
+  border-top: 1px solid rgba(102, 126, 234, 0.35) !important;
+  transform-origin: center !important;
+  box-shadow: inherit !important;
+}
+
+.header-background + .header-row .term-grade-badge:hover .term-grade-tooltip,
+.header-background + .header-row .term-grade-badge:focus-within .term-grade-tooltip {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: translate(-50%, 0) !important;
+}
+
+.header-background + .header-row .term-grade-badge:hover {
+  transform: translateY(-2px) !important;
+  box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;
+}
+
+.header-background + .header-row .term-grade-label {
+  position: relative !important;
+  z-index: 1 !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 1px !important;
+  color: #4c63d2 !important;
+  text-transform: uppercase !important;
+  opacity: 0.85 !important;
+}
+
+.header-background + .header-row .term-grade-value {
+  position: relative !important;
+  z-index: 1 !important;
+  font-size: 24px !important;
+  font-weight: 800 !important;
+  color: #1b254b !important;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.65) !important;
+  line-height: 1.1 !important;
+}
+
+@media (max-width: 820px) {
+  .header-background + .header-row .general-progress-wrapper {
+    grid-template-columns: 1fr !important;
+  }
+
+  .header-background + .header-row .general-progress-label,
+  .header-background + .header-row .general-progress-bar,
+  .header-background + .header-row .term-grade-badge {
+    grid-column: 1 / -1 !important;
+  }
+
+  .header-background + .header-row .term-grade-badge {
+    justify-self: stretch !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    text-align: left !important;
+    gap: 12px !important;
+    padding: 16px 20px !important;
+  }
+
+  .header-background + .header-row .general-progress-label {
+    white-space: normal !important;
+  }
+
+  .header-background + .header-row .term-grade-badge::before {
+    background: radial-gradient(circle at 95% 10%, rgba(255, 255, 255, 0.75), transparent 65%) !important;
+  }
+
+  .header-background + .header-row .term-grade-label {
+    font-size: 10px !important;
+    letter-spacing: 0.8px !important;
+  }
+
+  .header-background + .header-row .term-grade-value {
+    font-size: 22px !important;
+  }
 }
 
 /* Target ONLY form box in the specific header-row after header-background */

--- a/as/dashboard.html
+++ b/as/dashboard.html
@@ -27,6 +27,13 @@
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>
         </div>
+        <div class="term-grade-badge" aria-describedby="term-grade-tooltip" tabindex="0">
+          <span class="term-grade-label">TERM 1 GRADE</span>
+          <span id="term-grade-value" class="term-grade-value">0%</span>
+          <div id="term-grade-tooltip" class="term-grade-tooltip" role="tooltip">
+            Term 1 grade = 1×(Layer 1 passed) + 2×(Layer 2 passed) + 3×(Layer 3 passed) + 4×(Layer 4 passed).
+          </div>
+        </div>
     </div>
   </div>
 

--- a/as/dashboard.js
+++ b/as/dashboard.js
@@ -5,6 +5,7 @@ import { initializeLogin, fetchProgressCounts, verifyPlatform } from "./modules/
 
 async function updateGeneralProgress() {
   const fill = document.querySelector(".general-progress-fill");
+  const termGradeEl = document.getElementById("term-grade-value");
   if (!fill) return;
   console.log('[dashboard] Updating general progress');
 
@@ -21,7 +22,19 @@ async function updateGeneralProgress() {
 
   const totalLevels = 16; // defined in levelRenderer
 
-  const { points, levels } = await fetchProgressCounts();
+  const { points, levels, term1Grade } = await fetchProgressCounts();
+
+  if (termGradeEl) {
+    const numericGrade = Number(term1Grade);
+    const sanitizedGrade = Number.isFinite(numericGrade)
+      ? Math.min(100, Math.max(0, numericGrade))
+      : 0;
+    const formattedGrade = Number.isInteger(sanitizedGrade)
+      ? sanitizedGrade.toString()
+      : sanitizedGrade.toFixed(1);
+
+    termGradeEl.textContent = `${formattedGrade}%`;
+  }
 
   const total = totalPoints + totalLevels;
   const done = points + levels;
@@ -31,6 +44,17 @@ async function updateGeneralProgress() {
 
   fill.textContent = roundedPercent + "%";
   fill.style.setProperty("width", clampedPercent + "%", "important");
+
+  fill.classList.remove("progress-low", "progress-medium", "progress-high");
+
+  let progressClass = "progress-low";
+  if (roundedPercent >= 67) {
+    progressClass = "progress-high";
+  } else if (roundedPercent >= 34) {
+    progressClass = "progress-medium";
+  }
+
+  fill.classList.add(progressClass);
   console.debug('[dashboard] Progress percent', roundedPercent);
 }
 

--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -128,10 +128,11 @@ body {
 
 /* Target ONLY progress wrapper in the specific header-row after header-background */
 .header-background + .header-row .general-progress-wrapper {
-  display: flex !important;
+  display: grid !important;
+  grid-template-columns: auto minmax(0, 1fr) auto !important;
   align-items: center !important;
-  gap: 18px !important;
-  justify-content: flex-start !important;
+  gap: 12px 18px !important;
+  justify-content: stretch !important;
   background: rgba(255, 255, 255, 0.95) !important;
   backdrop-filter: blur(15px) !important;
   padding: 18px 24px !important;
@@ -139,7 +140,7 @@ body {
   border: 2px solid rgba(102, 126, 234, 0.2) !important;
   box-shadow: 0 8px 25px rgba(102, 126, 234, 0.15) !important;
   position: relative !important;
-  overflow: hidden !important;
+  overflow: visible !important;
 }
 
 .header-background + .header-row .general-progress-wrapper::before {
@@ -160,6 +161,7 @@ body {
 }
 
 .header-background + .header-row .general-progress-label {
+  grid-column: 1 / 2 !important;
   display: block !important;
   font-weight: 800 !important;
   font-size: 12px !important;
@@ -173,17 +175,19 @@ body {
   text-shadow: 0 1px 2px rgba(0, 0, 0, 0.1) !important;
   z-index: 1 !important;
   position: relative !important;
+  align-self: start !important;
 }
 
 .header-background + .header-row .general-progress-bar {
-  flex-grow: 1 !important;
+  grid-column: 2 / 3 !important;
+  width: 100% !important;
   height: 14px !important;
   background: #e2e8f0 !important;
   border-radius: 50px !important;
   position: relative !important;
   overflow: hidden !important;
   box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.15) !important;
-  min-width: 320px !important;
+  min-width: clamp(200px, 35vw, 320px) !important;
   border: 1px solid rgba(102, 126, 234, 0.2) !important;
 }
 
@@ -202,6 +206,21 @@ body {
   transition: width 1s cubic-bezier(0.4, 0, 0.2, 1) !important;
   animation: finalHeaderGradientFlow 4s ease infinite !important;
   box-shadow: 0 2px 8px rgba(102, 126, 234, 0.4) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-low {
+  background: linear-gradient(90deg, #ef4444 0%, #f97316 100%) !important;
+  box-shadow: 0 2px 8px rgba(239, 68, 68, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-medium {
+  background: linear-gradient(90deg, #f59e0b 0%, #fbbf24 100%) !important;
+  box-shadow: 0 2px 8px rgba(245, 158, 11, 0.45) !important;
+}
+
+.header-background + .header-row .general-progress-fill.progress-high {
+  background: linear-gradient(90deg, #10b981 0%, #059669 100%) !important;
+  box-shadow: 0 2px 8px rgba(16, 185, 129, 0.45) !important;
 }
 
 @keyframes finalHeaderGradientFlow {
@@ -235,6 +254,143 @@ body {
   line-height: 14px !important;
   font-weight: 600 !important;
   text-shadow: 0 1px 2px rgba(255, 255, 255, 0.8) !important;
+}
+
+.header-background + .header-row .term-grade-badge {
+  grid-column: 3 / 4 !important;
+  justify-self: end !important;
+  display: flex !important;
+  flex-direction: column !important;
+  align-items: center !important;
+  justify-content: center !important;
+  gap: 6px !important;
+  padding: 14px 18px !important;
+  min-width: 132px !important;
+  border-radius: 18px !important;
+  background: linear-gradient(135deg, rgba(102, 126, 234, 0.18) 0%, rgba(118, 75, 162, 0.22) 100%) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 10px 25px rgba(102, 126, 234, 0.18) !important;
+  position: relative !important;
+  overflow: hidden !important;
+  isolation: isolate !important;
+  transition: transform 0.3s ease, box-shadow 0.3s ease !important;
+}
+
+.header-background + .header-row .term-grade-badge::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.7), transparent 60%) !important;
+  opacity: 0.85;
+  z-index: 0;
+}
+
+.header-background + .header-row .term-grade-tooltip {
+  position: absolute !important;
+  top: calc(100% + 12px) !important;
+  left: 50% !important;
+  transform: translate(-50%, -6px) !important;
+  padding: 10px 16px !important;
+  border-radius: 10px !important;
+  background: rgba(255, 255, 255, 0.98) !important;
+  border: 1px solid rgba(102, 126, 234, 0.35) !important;
+  box-shadow: 0 12px 30px rgba(27, 37, 75, 0.18) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  color: #1b254b !important;
+  white-space: nowrap !important;
+  z-index: 10 !important;
+  opacity: 0 !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease !important;
+}
+
+.header-background + .header-row .term-grade-tooltip::before {
+  content: '' !important;
+  position: absolute !important;
+  bottom: 100% !important;
+  left: 50% !important;
+  transform: translateX(-50%) rotate(45deg) !important;
+  width: 12px !important;
+  height: 12px !important;
+  background: inherit !important;
+  border-left: 1px solid rgba(102, 126, 234, 0.35) !important;
+  border-top: 1px solid rgba(102, 126, 234, 0.35) !important;
+  transform-origin: center !important;
+  box-shadow: inherit !important;
+}
+
+.header-background + .header-row .term-grade-badge:hover .term-grade-tooltip,
+.header-background + .header-row .term-grade-badge:focus-within .term-grade-tooltip {
+  opacity: 1 !important;
+  visibility: visible !important;
+  transform: translate(-50%, 0) !important;
+}
+
+.header-background + .header-row .term-grade-badge:hover {
+  transform: translateY(-2px) !important;
+  box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;
+}
+
+.header-background + .header-row .term-grade-label {
+  position: relative !important;
+  z-index: 1 !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 1px !important;
+  color: #4c63d2 !important;
+  text-transform: uppercase !important;
+  opacity: 0.85 !important;
+}
+
+.header-background + .header-row .term-grade-value {
+  position: relative !important;
+  z-index: 1 !important;
+  font-size: 24px !important;
+  font-weight: 800 !important;
+  color: #1b254b !important;
+  text-shadow: 0 1px 2px rgba(255, 255, 255, 0.65) !important;
+  line-height: 1.1 !important;
+}
+
+@media (max-width: 820px) {
+  .header-background + .header-row .general-progress-wrapper {
+    grid-template-columns: 1fr !important;
+  }
+
+  .header-background + .header-row .general-progress-label,
+  .header-background + .header-row .general-progress-bar,
+  .header-background + .header-row .term-grade-badge {
+    grid-column: 1 / -1 !important;
+  }
+
+  .header-background + .header-row .term-grade-badge {
+    justify-self: stretch !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    text-align: left !important;
+    gap: 12px !important;
+    padding: 16px 20px !important;
+  }
+
+  .header-background + .header-row .general-progress-label {
+    white-space: normal !important;
+  }
+
+  .header-background + .header-row .term-grade-badge::before {
+    background: radial-gradient(circle at 95% 10%, rgba(255, 255, 255, 0.75), transparent 65%) !important;
+  }
+
+  .header-background + .header-row .term-grade-label {
+    font-size: 10px !important;
+    letter-spacing: 0.8px !important;
+  }
+
+  .header-background + .header-row .term-grade-value {
+    font-size: 22px !important;
+  }
 }
 
 /* Target ONLY form box in the specific header-row after header-background */

--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -29,6 +29,13 @@
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>
         </div>
+        <div class="term-grade-badge" aria-describedby="term-grade-tooltip" tabindex="0">
+          <span class="term-grade-label">TERM 1 GRADE</span>
+          <span id="term-grade-value" class="term-grade-value">0%</span>
+          <div id="term-grade-tooltip" class="term-grade-tooltip" role="tooltip">
+            Term 1 grade = 1×(Layer 1 passed) + 2×(Layer 2 passed) + 3×(Layer 3 passed) + 4×(Layer 4 passed).
+          </div>
+        </div>
     </div>
   </div>
 

--- a/igcse/dashboard.js
+++ b/igcse/dashboard.js
@@ -5,6 +5,7 @@ import { initializeLogin, fetchProgressCounts, verifyPlatform } from "./modules/
 
 async function updateGeneralProgress() {
   const fill = document.querySelector(".general-progress-fill");
+  const termGradeEl = document.getElementById("term-grade-value");
   if (!fill) return;
   console.log('[dashboard] Updating general progress');
 
@@ -21,7 +22,19 @@ async function updateGeneralProgress() {
 
   const totalLevels = 16; // defined in levelRenderer
 
-  const { points, levels } = await fetchProgressCounts();
+  const { points, levels, term1Grade } = await fetchProgressCounts();
+
+  if (termGradeEl) {
+    const numericGrade = Number(term1Grade);
+    const sanitizedGrade = Number.isFinite(numericGrade)
+      ? Math.min(100, Math.max(0, numericGrade))
+      : 0;
+    const formattedGrade = Number.isInteger(sanitizedGrade)
+      ? sanitizedGrade.toString()
+      : sanitizedGrade.toFixed(1);
+
+    termGradeEl.textContent = `${formattedGrade}%`;
+  }
 
   const total = totalPoints + totalLevels;
   const done = points + levels;
@@ -31,6 +44,17 @@ async function updateGeneralProgress() {
 
   fill.textContent = roundedPercent + "%";
   fill.style.setProperty("width", clampedPercent + "%", "important");
+
+  fill.classList.remove("progress-low", "progress-medium", "progress-high");
+
+  let progressClass = "progress-low";
+  if (roundedPercent >= 67) {
+    progressClass = "progress-high";
+  } else if (roundedPercent >= 34) {
+    progressClass = "progress-medium";
+  }
+
+  fill.classList.add(progressClass);
   console.debug('[dashboard] Progress percent', roundedPercent);
 }
 

--- a/igcse/modules/supabase.js
+++ b/igcse/modules/supabase.js
@@ -28,12 +28,29 @@ function tableName(platform, type) {
   return map[platform] ? map[platform][type] : null;
 }
 
+const LAYER_WEIGHTS = Object.freeze({
+  0: 0,
+  1: 1,
+  2: 3,
+  3: 6,
+  4: 10
+});
+
+function weightForLayer(value) {
+  if (typeof value === 'string' && value.toUpperCase() === 'R') return 0;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return 0;
+  return LAYER_WEIGHTS[parsed] ?? 0;
+}
+
 export async function fetchProgressCounts() {
   console.log('[supabaseModule] Fetching progress counts');
   const username = localStorage.getItem('username');
   const platform = localStorage.getItem('platform');
 
-  if (!username || !platform) return { points: 0, levels: 0 };
+  if (!username || !platform) return { points: 0, levels: 0, term1Grade: 0 };
+
+  const encodedUsername = encodeURIComponent(username);
 
   const theoryTable = tableName(platform, 'theory');
   const levelTable = tableName(platform, 'programming');
@@ -41,13 +58,13 @@ export async function fetchProgressCounts() {
 
   try {
     const [tRes, lRes] = await Promise.all([
-      fetch(`${base}/${theoryTable}?select=reached_layer&username=eq.${encodeURIComponent(username)}`, {
+      fetch(`${base}/${theoryTable}?select=reached_layer&username=eq.${encodedUsername}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
         }
       }),
-      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' || platform === 'IGCSE' ? 'reached_level' : 'level_done'}&username=eq.${encodeURIComponent(username)}`, {
+      fetch(`${base}/${levelTable}?select=${platform === 'A_Level' || platform === 'IGCSE' ? 'reached_level' : 'level_done'}&username=eq.${encodedUsername}`, {
         headers: {
           apikey: SUPABASE_KEY,
           Authorization: 'Bearer ' + SUPABASE_KEY
@@ -58,16 +75,21 @@ export async function fetchProgressCounts() {
     const tData = await tRes.json();
     const lData = await lRes.json();
 
-    const passedPoints = tData.filter(r => r.reached_layer === '4').length;
+    const passedPoints = tData.filter(r => String(r.reached_layer) === '4').length;
+    const rawGrade = tData.reduce(
+      (total, record) => total + weightForLayer(record.reached_layer),
+      0
+    );
+    const term1Grade = Math.max(0, rawGrade - 1);
     const rawReachedLevel = lData.length ? lData[0]?.reached_level ?? 0 : 0;
     const numericReachedLevel = Number(rawReachedLevel);
     const passedLevels = Number.isFinite(numericReachedLevel) ? numericReachedLevel : 0;
-    const result = { points: passedPoints, levels: passedLevels };
+    const result = { points: passedPoints, levels: passedLevels, term1Grade };
     console.log('[supabaseModule] Progress counts', result);
     return result;
   } catch (err) {
     console.error('❌ Failed fetching progress counts:', err);
-    return { points: 0, levels: 0 };
+    return { points: 0, levels: 0, term1Grade: 0 };
   }
 }
 


### PR DESCRIPTION
## Summary
- add the Term 1 grade badge component to the AS and IGCSE dashboards with tooltip copy matching the A Level view
- update dashboard scripts and Supabase helpers to calculate and display the term grade alongside progress styling updates

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d9bef77e18833185d78ed9b9f2e910