### PR TITLE
Fix tooltip positioning on IGCSE dashboard

### DIFF
--- a/igcse/dashboard.css
+++ b/igcse/dashboard.css
@@ -271,11 +271,7 @@ body {
   border: 1px solid rgba(102, 126, 234, 0.35) !important;
   box-shadow: 0 10px 25px rgba(102, 126, 234, 0.18) !important;
   position: relative !important;
-<<<<<<< HEAD
   overflow: hidden !important;
-=======
-  overflow: visible !important;
->>>>>>> 2b2536de9a5b8ab262e986040397da66f84300ca
   isolation: isolate !important;
   transition: transform 0.3s ease, box-shadow 0.3s ease !important;
 }
@@ -287,11 +283,7 @@ body {
   background: radial-gradient(circle at 80% 0%, rgba(255, 255, 255, 0.7), transparent 60%) !important;
   opacity: 0.85;
   z-index: 0;
-<<<<<<< HEAD
-=======
   border-radius: inherit;
-
->>>>>>> 2b2536de9a5b8ab262e986040397da66f84300ca
 }
 
 .header-background + .header-row .term-grade-tooltip {
@@ -337,7 +329,6 @@ body {
   transform: translate(-50%, 0) !important;
 }
 
-<<<<<<< HEAD
 .dashboard .tooltip-container {
   position: relative;
   display: inline-flex;
@@ -394,9 +385,6 @@ body {
   visibility: visible;
   transform: translate(-50%, 0);
 }
-
-=======
->>>>>>> 2b2536de9a5b8ab262e986040397da66f84300ca
 .header-background + .header-row .term-grade-badge:hover {
   transform: translateY(-2px) !important;
   box-shadow: 0 16px 35px rgba(102, 126, 234, 0.28) !important;

--- a/igcse/dashboard.html
+++ b/igcse/dashboard.html
@@ -57,7 +57,7 @@
     <div class="section-header tooltip-container" tabindex="0" aria-describedby="advanced-theory-tooltip">
       <img src="./images/advanced_theory.png" alt="Advanced Theory" class="section-title" style="transform: scale(1.3); transform-origin: center;"/>
       <div id="advanced-theory-tooltip" class="image-tooltip" role="tooltip">
-        Term 1 target: finish 10 syllabus points.
+        Term 1 target: finish 4 syllabus points.
       </div>
     </div>
     <div id="theory-points" class="theory-wrapper"></div>
@@ -68,7 +68,7 @@
     <div class="section-header tooltip-container" tabindex="0" aria-describedby="programming-skills-tooltip">
       <img src="./images/programming_skills.png" alt="Programming Skills" class="section-title"/>
       <div id="programming-skills-tooltip" class="image-tooltip" role="tooltip">
-        Term 1 target: reach level 12.
+        Term 1 target: reach level 3.
       </div>
     </div>
     <div id="programming-levels" class="levels-wrapper"></div>


### PR DESCRIPTION
## Summary
- resolve lingering merge markers in the IGCSE dashboard stylesheet so image tooltips render next to their headers
- update the tooltip copy to reflect the Term 1 targets for syllabus points and programming levels

## Testing
- Manual verification of tooltip alignment in the browser

------
https://chatgpt.com/codex/tasks/task_e_68da937a7964833181fbff439e3c0801