### PR TITLE
Fix IGCSE term grade offset

### DIFF
--- a/igcse/modules/supabase.js
+++ b/igcse/modules/supabase.js
@@ -97,12 +97,13 @@ export async function fetchProgressCounts() {
     const rawReachedLevel = lData.length ? lData[0]?.reached_level ?? 0 : 0;
     const numericReachedLevel = Number(rawReachedLevel);
     const passedLevels = Number.isFinite(numericReachedLevel) ? numericReachedLevel : 0;
-    const term1Grade =
+    const rawTerm1Grade =
       20 * passedLevels +
       1 * layer1Passed +
       2 * layer2Passed +
       3 * layer3Passed +
       4 * layer4Passed;
+    const term1Grade = Math.max(0, rawTerm1Grade - 3);
 
     const result = { points: passedPoints, levels: passedLevels, term1Grade };
     console.log('[supabaseModule] Progress counts', result);


### PR DESCRIPTION
## Summary
- adjust the IGCSE term one grade calculation to remove the unwanted +3 offset by subtracting three from the computed value
- ensure the grade cannot drop below zero when applying the correction

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68daf03ffb3883318a0c887ba088eda7