### PR TITLE
Route IGCSE levels directly to dedicated pages

### DIFF
--- a/igcse/dashboard.js
+++ b/igcse/dashboard.js
@@ -1,6 +1,6 @@
 
 import { renderTheoryPoints } from "./modules/theoryRenderer.js";
-import { renderProgrammingLevels } from "./modules/levelRenderer.js";
+import { renderProgrammingLevels, levels } from "./modules/levelRenderer.js";
 import { initializeLogin, fetchProgressCounts, verifyPlatform } from "./modules/supabase.js";
 
 async function updateGeneralProgress() {
@@ -20,7 +20,7 @@ async function updateGeneralProgress() {
     console.error("Failed to load points index:", err);
   }
 
-  const totalLevels = 16; // defined in levelRenderer
+  const totalLevels = levels.length;
 
   const { points, levels, term1Grade } = await fetchProgressCounts();
 

--- a/igcse/levels/level1.html
+++ b/igcse/levels/level1.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 1: Introduction to Algorithms</title>
+  <link rel="stylesheet" href="./levels.css">
+</head>
+<body>
+<!-- Header -->
+<div class="header">
+  <div class="container">
+    <!-- Top bar: logo + brand on the left, Home on the right -->
+    <div class="header-bar">
+      <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+        <img src="./logo.png" alt="logo" class="brand-logo">
+      </a>
+	  <div class="header-main">
+      <h1>Level 1: Introduction to Algorithms</h1>
+      <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+    </div>
+     <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+  <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+    <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z"/>
+  </svg>
+  <span>Home</span>
+</a>
+
+    </div>
+
+    <!-- Centered title block -->
+    
+  </div>
+</div>
+
+  <div class="container">
+
+    <div class="toc">
+      <strong>Contents</strong>
+      <ol>
+        <li><a href="#s1">Understand each phase of the program development life cycle</a></li>
+        <li><a href="#s2">Understand that every computer system is made up of sub-systems, which are made up of further sub-systems</a></li>
+        <li><a href="#s3">Understand problem decomposition into Inputs, Processes, Outputs, Storage</a></li>
+        <li><a href="#s4">Understand the purpose of algorithms</a></li>
+        <li><a href="#s5">Understand and use different methods to design solutions</a></li>
+      </ol>
+    </div>
+
+    <!-- Section 1 -->
+    <div class="section" id="s1">
+      <h2>1. Understand each phase of the program development life cycle</h2>
+      <p>The program development life cycle is the standard process used to build software and it is composed of four steps  analysis, Design, Coding then Testing</p>
+
+      <ol class="bullets">
+        <li><strong>Analysis</strong> identifies the problem and produces a clear <strong>requirements specification</strong> (a short, written list of what the program must do and how it will be checked).
+          <ul>
+            <li><strong>Abstraction</strong> means keeping only essential details and removing non-essential information.</li>
+            <li><strong>Decomposition</strong> splits a large problem into smaller parts (sub-tasks or <strong>modules</strong>, where a module is a small part of a program that does one job, for example “calculate total”).</li>
+          </ul>
+          <div class="example">
+            <div class="title"><strong>Example: Abstraction in everyday life</strong></div>
+            <p>Think of maps for different purposes. A road map shows roads and junctions; a rail map shows lines and stations. Each map removes details that are not needed for its task so the essential information stands out.</p>
+          </div>
+          <div class="example">
+            <div class="title"><strong>Example: Decomposition of a routine</strong></div>
+            <p>Getting dressed can be broken into smaller, ordered steps:<br>
+            1) choose items<br>
+            2) remove current clothing if needed<br>
+            3) put on items in a sensible order.<br>
+            In code, these could be functions such as <em>chooseItems()</em> and <em>putOnShirt()</em>.</p>
+          </div>
+        </li>
+
+        <li><strong>Design</strong> plans the solution using the approved specification from analysis.
+          <ul>
+            <li>Decomposition continues to organise tasks and their interactions.</li>
+            <li>The design states <em>what</em> each part should do, <em>how</em> it should do it, and <em>how</em> parts fit together.</li>
+            <li>The design is recorded with <strong>structure diagrams</strong> (tree diagrams that show parts under the whole), <strong>flowcharts</strong> (diagrams of steps using standard shapes), and <strong>pseudocode</strong> (code-like English). These 3 tools will be the focus of all next levels.</li>
+          </ul>
+        </li>
+
+        <li><strong>Coding</strong> implements each module in a suitable programming language (like python, java or VB.NET) after the algorithms are designed.
+          <ul>
+            <li><strong>Iterative modular testing</strong> is carried out during development.</li>
+            <li>Code is amended until each module works as required.</li>
+          </ul>
+        </li>
+
+        <li><strong>Testing</strong> checks the completed program using varied test data to confirm correctness and that requirements are met.
+          <ul>
+            <li>Use <strong>normal</strong> (typical), <strong>abnormal</strong> (invalid), <strong>extreme</strong> (at the ends), and <strong>boundary</strong> test data (just inside/just outside the allowed limits).</li>
+            <li>Testing confirms that all tasks work together as designed.</li>
+          </ul>
+          <div class="example">
+            <div class="title"><strong>Example: Age input data sets</strong></div>
+            <p>Allowed whole numbers 10 to 100<br>
+            Normal: 10, 50, 100<br>
+            Abnormal: 9, −1, 101, "age"<br>
+            Extreme: 10 and 100<br>
+            Boundary pairs: 9 vs 10; 100 vs 101</p>
+          </div>
+          <div class="example">
+            <div class="title"><strong>Example: Password length data sets</strong></div>
+            <p>Minimum 8 characters<br>
+            Normal: "abcdefgh"<br>
+            Abnormal: "1234567"<br>
+            Extreme: exactly 8 characters<br>
+            Boundary pair: 7 vs 8 characters</p>
+          </div>
+        </li>
+      </ol>
+
+      <div class="example video video-pink">
+        <div class="title">  Program Development Life Cycle</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/cY0GjVzmo8s" title="CAMBRIDGE IGCSE (0478-0984) 7 Software development life cycle" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section 2 -->
+    <div class="section" id="s2">
+      <h2>2. Understand that every computer system is made up of sub-systems, which are made up of further sub-systems</h2>
+      <ul class="bullets">
+        <li>A computer system can be divided into <strong>sub-systems</strong> and then into smaller sub-systems until each unit performs a single, clear action.
+          <ul>
+            <li>A computer system typically involves <strong>hardware</strong>, <strong>software</strong>, <strong>data</strong>, <strong>communications</strong>, and <strong>people</strong> (users and technicians who operate or maintain the system).</li>
+            <li><strong>Top-down design</strong> means starting from the whole app, then splitting it into screens or features, and repeatedly splitting each feature until a single action remains, like “save file”.</li>
+            <li><strong>Structure diagrams</strong> show this hierarchy as a tree; each box can later become a subprogram, function, or procedure.</li>
+          </ul>
+          <div class="example">
+            <div class="title"><strong>Example: Calculator structure diagram</strong></div>
+            <p>This example shows a calculator represented in a structure diagram.</p>
+            <img src="./Level%200/calculator_structure_diagram.png" alt="Calculator structure diagram" width="600">
+          </div>
+        </li>
+      </ul>
+
+      <div class="example video video-pink">
+        <div class="title">  Computer sub-systems</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/j51R215dNs0" title="CAMBRIDGE IGCSE (0478-0984) 7 Computer sub-systems" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section 3 -->
+    <div class="section" id="s3">
+      <h2>3. Understand problem decomposition into Inputs, Processes, Outputs, Storage</h2>
+      <ul class="bullets">
+        <li>Problems can be decomposed into <strong>Inputs</strong>, <strong>Processes</strong>, <strong>Outputs</strong>, and <strong>Storage</strong> (IPOS).
+          <ul>
+            <li><strong>Inputs</strong>: data entered while the system runs.</li>
+            <li><strong>Processes</strong>: computations or decisions on current inputs and previously stored data.</li>
+            <li><strong>Outputs</strong>: information shown or printed for users.</li>
+            <li><strong>Storage</strong>: data kept for use during and after execution (variables, constants, arrays); <strong>persistent storage</strong> saves data in files on a device such as a hard drive, SSD, or USB stick.</li>
+          </ul>
+          <div class="example">
+            <div class="title"><strong>Example: Alarm app (IPOS)</strong></div>
+            <p>Input: set or clear alarm time; press snooze<br>
+            Process: check current time; manage snooze timing<br>
+            Output: play alarm sound<br>
+            Storage: store the alarm time(s)</p>
+          </div>
+        </li>
+      </ul>
+
+      <div class="example video video-pink">
+        <div class="title">  Inputs, processes, outputs, and storage</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/Cc9VFuTKggo" title="CAMBRIDGE IGCSE (0478-0984) 7 Inputs, processes, outputs and storage" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section 4 -->
+    <div class="section" id="s4">
+      <h2>4. Understand the purpose of algorithms</h2>
+      <ul class="bullets">
+        <li>An <strong>algorithm</strong> is the ordered list of steps to complete a task; it makes the required processes explicit.
+          <ul>
+            <li>Common processes include <strong>linear search</strong>, <strong>bubble sort</strong>, <strong>totalling</strong>, <strong>counting</strong>, <strong>minimum/maximum</strong>, and <strong>average</strong> calculations.</li>
+          </ul>
+          <div class="example">
+            <div class="title"><strong>Example: Alarm-time algorithm</strong></div>
+            <p>Imagine you are coding a phone alarm that rings at 07:00.<br>
+            A simple algorithm can:<br>
+            1) wait a short interval (for example, 10 seconds)<br>
+            2) read the current time<br>
+            3) compare it with the stored alarm time<br>
+            4) play the alarm sound when they match</p>
+          </div>
+          <div class="example">
+            <div class="title"><strong>Example: Average of a set of marks</strong></div>
+            <p>To compute the class average: <br> 1. decide the list of marks to include; <br> 2. set Total to 0 (initially); <br> 3.  add each mark to Total one by one; <br> 4. at the end divide Total by the number of marks; <br> 5. report the resulting value as the average.</p>
+          </div>
+          <div class="example">
+            <div class="title"><strong>Example: Minimum value in a list</strong></div>
+            <p>To find the smallest temperature in a list: <br> 1. start by assuming the first temperature is the minimum; <br> 2. compare each remaining temperature with the current minimum; <br> 3. whenever a smaller value is found, replace the current minimum with it; <br> 4. after the scan finishes, report the final minimum.</p>
+          </div>
+          <li>Algorithms are commonly shown as <strong>flowcharts</strong> or <strong>pseudocode</strong>. A <strong>trace table</strong> supports a dry run to infer purpose and detect logic errors using sample data.</li>
+        </li>
+      </ul>
+
+      <div class="example video video-pink">
+        <div class="title">  What is an algorithm</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/qiMpOYKlruc" title="CAMBRIDGE IGCSE (0478-0984) 7 What is an algorithm" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div>
+    </div>
+
+    <!-- Section 5 -->
+    <div class="section" id="s5">
+      <h2>5. Understand and use different methods to design solutions</h2>
+      <ul class="bullets">
+        <li><strong>Flowcharts</strong> show the steps of an algorithm in order using standard symbols.
+          <ul>
+            <li>Key symbols: <strong>Terminator</strong> (rounded rectangle for Start/End), <strong>Process</strong> (rectangle), <strong>Input/Output</strong> (parallelogram), <strong>Decision</strong> (diamond), and directed flow lines (arrows).</li>
+          </ul>
+          <img src="./Level%200/flowchart.png" alt="Flowchart example" width="400">
+        </li>
+
+        <li><strong>Pseudocode</strong> is a language-independent, code-like description of an algorithm that uses meaningful names.
+          <ul>
+            <li>It is not limited by strict programming syntax but is precise enough to convert into code.</li>
+            <li>Core constructs include: <br> <strong>Assignment</strong> (←), <strong>Selection</strong> (IF..THEN..ELSE..ENDIF; CASE OF..OTHERWISE..ENDCASE), <strong>Iteration</strong> (FOR..TO..NEXT; REPEAT..UNTIL; WHILE..DO..ENDWHILE), and <strong>Input/Output</strong> (INPUT, OUTPUT).</li>
+          </ul>
+          <img src="./Level%200/pseudocode.png" alt="Pseudocode example" width="400">
+        </li>
+
+        <li><strong>Trace tables</strong> help follow variable values step by step during a dry run to infer purpose and detect logic errors using sample data.</li>
+        <img src="./Level%200/trace_table.png" alt="Trace table example" width="400">
+      </ul>
+
+
+
+<table>
+  <tr>
+    <th>  <div class="example video video-pink">
+        <div class="title">  Structure diagrams</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/gFY9QdxMInI" title="CAMBRIDGE IGCSE (0478-0984) 7 Structure diagrams" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div>
+	</th>
+	
+    <th> <div class="example video video-pink">
+        <div class="title">  Producing algorithms using pseudocode and flowcharts</div>
+        <div class="media">
+          <iframe src="https://www.youtube.com/embed/kSpUGDYBnww" title="CAMBRIDGE IGCSE (0478-0984) 7 How to produce algorithms using pseudocode and flowcharts" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        </div>
+      </div></th>
+  </tr>
+  </table>
+  
+
+
+      <br> <strong>Note:</strong> This is a general overview of pseudocode, flowcharts, and trace tables. Mastery of these skills will be developed progressively in the upcoming levels.
+    </div>
+
+    <center><a href="./Level%200/exercises.html" class="btn btn-cta" role="button">Ready to Practice</a></center>
+    <div class="footer">© IGCSE CS (0478) - Student notes prepared by Dr. Hamdeni 2026</div>
+  </div>
+</body>
+</html>

--- a/igcse/levels/level10.html
+++ b/igcse/levels/level10.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 10: File Handling</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 10: File Handling</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 10 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level11.html
+++ b/igcse/levels/level11.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 11: Validation, Verification, and Error Handling</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 11: Validation, Verification, and Error Handling</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 11 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level12.html
+++ b/igcse/levels/level12.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 12: Dry Runs, Trace Tables, and Test Data</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 12: Dry Runs, Trace Tables, and Test Data</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 12 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level13.html
+++ b/igcse/levels/level13.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 13: Systems decomposition, Procedures, Functions</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 13: Systems decomposition, Procedures, Functions</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 13 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level14.html
+++ b/igcse/levels/level14.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 14: Comprehensive Problem-solving</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 14: Comprehensive Problem-solving</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 14 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level2.html
+++ b/igcse/levels/level2.html
@@ -1,0 +1,415 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 2: Programming Basics</title>
+  <link rel="stylesheet" href="./levels.css">
+</head>
+<body>
+
+
+<!-- Header -->
+<div class="header">
+  <div class="container">
+    <!-- Top bar: logo + brand on the left, Home on the right -->
+    <div class="header-bar">
+      <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+        <img src="./logo.png" alt="logo" class="brand-logo">
+      </a>
+	  <div class="header-main">
+      <h1>Level 2: Programming Basics</h1>
+      <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+    </div>
+     <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+  <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+    <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z"/>
+  </svg>
+  <span>Home</span>
+</a>
+
+    </div>
+
+    <!-- Centered title block -->
+    
+  </div>
+</div>
+
+
+<div class="container">
+  <div class="toc">
+    <strong>Contents</strong>
+    <ol>
+      <li><a href="#s1">Introduction to basic data types: Integer, Real, Char, String, Boolean</a></li>
+      <li><a href="#s2">Declare and use variables and constants: use meaningful identifiers for Variables and Constants</a></li>
+      <li><a href="#s3">Understand and use input and output</a></li>
+      <li><a href="#s4">Clearly apply maintainability concepts from the start, including: Appropriate use of meaningful identifiers and Appropriate use of comments in code</a></li>
+      <li><a href="#s5">Understand and use sequence (step-by-step instructions)</a></li>
+      <li><a href="#s6">Understand Flowchart symbols related to start, stop, input, output and process</a></li>
+      <li><a href="#s7">Apply arithmetic operations: +, -, /, *, ^ (raised to power)</a></li>
+      <li><a href="#s8">Use arithmetic-related library routines: MOD, DIV, ROUND, RANDOM</a></li>
+      <li><a href="#s9">Apply relational operators: =, &lt;, &lt;=, &gt;, &gt;=, &lt;&gt; (not equal)</a></li>
+      <li><a href="#s10">Use logical operators: AND, OR, NOT</a></li>
+	   <li><a href="./Level%201/basics.pdf"
+       onclick="return openPdfPopup();"
+       target="_blank" rel="noopener"
+       aria-label="Open the Selection PDF in a centered popup window">
+      Cambridge Pseudocode Syntax
+    </a></li>
+    </ol>
+  </div>
+  <div class="section" id="s1">
+    <h2>1. Introduction to basic data types: Integer, Real, Char, String, Boolean</h2>
+    <ul class="bullets">
+      <li>The basic <strong>data types</strong> (the kind of data a variable can store) are <strong>Integer</strong> (whole number), <strong>Real</strong> (decimal number), <strong>Char</strong> (single character), <strong>String</strong> (sequence of characters), and <strong>Boolean</strong> (TRUE or FALSE).
+        <ul>
+          <li><strong>Integer</strong> stores whole numbers such as 4 or −12. Literals have no decimal point.</li>
+          <li><strong>Real</strong> stores decimal numbers such as 22.2 or 3.14.</li>
+          <li><strong>Char</strong> stores exactly one character (in quotes), for example &quot;A&quot; or &quot;9&quot;; use <strong>String</strong> for two or more characters.</li>
+          <li><strong>String</strong> stores text (in quotes), for example &quot;red&quot; or &quot;Hello&quot;.</li>
+          <li><strong>Boolean</strong> stores only TRUE or FALSE; write these in uppercase in this pseudocode.</li>
+          <li>Do not mix numbers stored as <strong>String</strong> with numeric calculations until converted; &quot;22&quot; is text, not a number.</li>
+        </ul>
+        <div class="example" >
+           <div class="title"><strong>Example: </strong> One clear assignment for each type.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="store an Integer whole number"><em>Amount ← 100</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store a Real with a decimal part"><em>Price ← 22.4</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store a Char value in quotes"><em>Letter ← &quot;M&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store a String value in quotes"><em>Colour ← &quot;red&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store a Boolean TRUE value"><em>Finished ← TRUE</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Basic data types </div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/ugq7ig1qU8E?start=11&end=205" title="IGCSE 8.1 Basic data types (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s2">
+    <h2>2. Declare and use variables and constants: use meaningful identifiers for Variables and Constants</h2>
+    <ul class="bullets">
+      <li>A <strong>variable</strong> (named memory location) can change while the program runs; a <strong>constant</strong> is named data that must not change; both should use <strong>meaningful identifiers</strong> that describe their purpose.
+        <ul>
+          <li>An <strong>identifier</strong> is the name of a variable or constant; it should clearly reflect its role (for example, TotalPrice, NumberOfStudents).</li>
+          <li><strong>Assignment</strong> stores a value in a variable using the left arrow ←; read this as &quot;stores into&quot;.</li>
+          <li>In this pseudocode you do not need to type the arrow on your keyboard; it is a symbol that shows assignment.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong>  Declaring and assigning variables and a constant with descriptive names.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="declare an Integer variable"><em>DECLARE FirstInteger : INTEGER</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="declare a Real variable"><em>DECLARE TotalPrice : REAL</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="define a constant"><em>CONSTANT PI ← 3.142</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="assign a String to a variable"><em>StudentName ← &quot;Alice&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="assign an Integer to a variable"><em>NumberOfStudents ← 25</em></span></div>
+          </div>
+        </div>
+		
+        <div class="example" >
+          <p>Additional variable and constant, as concise practice.</p>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="assign a String variable"><em>FavouriteColour ← &quot;blue&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="define a constant maximum score"><em>CONSTANT MaxScore ← 100</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Variables and constants </div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/Jot4qdPjieA" title="IGCSE 8.1 Variables and constants" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s3">
+    <h2>3. Understand and use input and output</h2>
+    <ul class="bullets">
+      <li><strong>Input</strong> is the user entering data into the program; <strong>Output</strong> is the program displaying information to the user.
+        <ul>
+          <li><strong>INPUT</strong> reads data into variables; <strong>OUTPUT</strong> shows text, numbers, or variable values.</li>
+          <li>Use a clear <strong>prompt</strong> before INPUT to tell the user what to enter.</li>
+          <li><strong>Concatenation</strong> means joining pieces of text and values; in this pseudocode OUTPUT uses comma-separated parts.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Ask for a name, store it, then output a personalized message.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="show a prompt"><em>OUTPUT &quot;Please enter your name: &quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="read user input into UserName"><em>INPUT UserName</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display a message using text and a variable"><em>OUTPUT &quot;Hello &quot;, UserName, &quot;. Welcome.&quot;</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  User input and display output </div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/atC6ZU0-vAk" title="IGCSE 8.1 User input and display output" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s4">
+    <h2>4. Clearly apply maintainability concepts from the start, including: Appropriate use of meaningful identifiers and Appropriate use of comments in code</h2>
+    <ul class="bullets">
+      <li>A <strong>maintainable program</strong> uses meaningful identifiers and <strong>comments</strong> so future readers can understand and safely modify the code.
+        <ul>
+          <li>Good identifiers make code self-documenting; write explanations as normal sentences around the code rather than inside the pseudocode lines.</li>
+          <li>Comments are preceded by two forward slashes: //. The comment continues until the end of the line. For
+multi-line comments, each line is preceded by //.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong>  Meaningless vs meaningful names; plus a focused explanation of intent.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="not meaningful"><em>x ← 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="meaningful identifier"><em>TotalScore ← 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="poor identifier"><em>X ← 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="poor identifier"><em>Y ← 20</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="poor identifier addition"><em>Z ← X + Y</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="good identifier"><em>NumberOfStudents ← 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="good identifier"><em>NumberOfTeachers ← 20</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="comments that will not be considered. only for explanation"><em>// if admin will be considered we need to update the code</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="sum with meaningful identifiers"><em>TotalPeople ← NumberOfStudents + NumberOfTeachers</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display the result"><em>OUTPUT &quot;Total people: &quot;, TotalPeople</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="multiply length by width to get area"><em>Area ← Length * Width</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Maintainability - naming and comments </div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/QGH4N3VfZpA" title="IGCSE 8.1 Maintainability" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s5">
+    <h2>5. Understand and use sequence (step-by-step instructions)</h2>
+    <ul class="bullets">
+      <li>A <strong>sequence</strong> runs statements once each in the written order; changing the order changes the result.
+        <ul>
+          <li>Variables must be created and assigned values before they are used in calculations or output.</li>
+          <li><strong>Order matters</strong> means that swapping two lines can give a different result.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Summing two test scores and then showing the result.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="store first score"><em>TestScore1 ← 85</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store second score"><em>TestScore2 ← 92</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="compute the sum"><em>TotalScore ← TestScore1 + TestScore2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display total"><em>OUTPUT &quot;Your total score is &quot;, TotalScore</em></span></div>
+          </div>
+        </div>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> A greeting that depends on the order of inputs.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="prompt for colour"><em>OUTPUT &quot;Enter a colour&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store colour"><em>INPUT Colour</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="prompt for name"><em>OUTPUT &quot;Enter your name&quot;</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store name"><em>INPUT Name</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display combined message"><em>OUTPUT Name, &quot; your favourite colour is &quot;, Colour</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Sequence (step-by-step)</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/QgffZbGnBvg?start=36&end=73" title="IGCSE 8.1 Sequence only (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s6">
+    <h2>6. Understand Flowchart symbols related to start, stop, input, output and process</h2>
+    <ul class="bullets">
+      <li>A <strong>flowchart</strong> is a diagram that uses standard symbols to represent the steps of an <strong>algorithm</strong> (step-by-step solution).
+        <ul>
+          <li><strong>Terminator</strong> ovals mark <strong>START</strong> and <strong>STOP</strong>.</li>
+          <li><strong>Process</strong> rectangles show actions such as calculations or assignments.</li>
+          <li><strong>Input/Output</strong> parallelograms represent reading data or displaying information.</li>
+          <li><strong>Flow lines</strong> (arrows) show execution direction, typically top to bottom.</li>
+         <img src="./Level%201/flowchart.png" alt="flwochart" width="400">
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> A simple linear flow using standard symbols.</div>
+          <p>START (oval) → INPUT Number (parallelogram) → Result ← Number * 2 (rectangle) → OUTPUT Result (parallelogram) → STOP (oval)</p>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Flowchart symbols</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/kSpUGDYBnww?start=214&end=277" title="IGCSE 7 Flowchart symbols only (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s7">
+    <h2>7. Apply arithmetic operations: +, -, /, *, ^ (raised to power)</h2>
+    <ul class="bullets">
+      <li><strong>Arithmetic operators</strong> perform calculations: + add, - subtract, * multiply, / divide, and ^ raise to a power; parentheses control evaluation order.
+        <ul>
+          
+          <li>+ adds two values.</li>
+          <li>− subtracts the second value from the first.</li>
+          <li>* multiplies two values.</li>
+          <li>/ divides the first number by the second; use <strong>DIV</strong> if you need the whole number part only.</li>
+          <li>^ is the power operator in this pseudocode; it raises the first number to the power of the second.</li>
+        
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Rectangle area and perimeter using + and *.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="store rectangle length"><em>Length ← 8</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="store rectangle width"><em>Width ← 5</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="compute area by multiplication"><em>Area ← Length * Width</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="compute perimeter using precedence"><em>Perimeter ← (Length + Width) * 2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display area"><em>OUTPUT &quot;Area is &quot;, Area</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display perimeter"><em>OUTPUT &quot;Perimeter is &quot;, Perimeter</em></span></div>
+          </div>
+        </div>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Circle area using ^ to square the radius.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="set radius"><em>Radius ← 4</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="set pi approximation"><em>PI ← 3.142</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="compute area using power"><em>Area ← PI * Radius ^ 2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display area"><em>OUTPUT &quot;Circle area is &quot;, Area</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Arithmetic operators</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/DR_hFLPysgM?start=28&end=201" title="IGCSE 8.1 Arithmetic operators only (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s8">
+    <h2>8. Use arithmetic-related library routines: MOD, DIV, ROUND, RANDOM</h2>
+    <ul class="bullets">
+      <li><strong>Library routines</strong> perform common operations: <strong>DIV</strong> returns the whole-number result of division, <strong>MOD</strong> returns the remainder, <strong>ROUND(number, places)</strong> rounds to a chosen number of decimal places, and <strong>RANDOM(low, high)</strong> generates a number in a given range.
+        <ul>
+          <li>Using DIV and MOD together shows quotient vs remainder for the same division.</li>
+          <li>ROUND takes two parameters: the value and the number of decimal places.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong>  DIV and MOD for operands 17 and 5.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="quotient of integer division"><em>WholeResult ← DIV(17, 5)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="remainder of the division"><em>Remainder ← MOD(17, 5)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display quotient and remainder"><em>OUTPUT &quot;17 divided by 5 is &quot;, WholeResult, &quot; remainder &quot;, Remainder</em></span></div>
+          </div>
+        </div>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> DIV and MOD for operands 11 and 3.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="quotient of integer division"><em>Q ← DIV(11, 3)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="remainder of the division"><em>R ← MOD(11, 3)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display quotient and remainder"><em>OUTPUT &quot;11 divided by 3 is &quot;, Q, &quot; remainder &quot;, R</em></span></div>
+          </div>
+        </div>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Rounding a calculated price.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="set base price"><em>Price ← 19.99</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="set tax rate"><em>TaxRate ← 0.075</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="compute total price with tax"><em>TotalPrice ← Price * (1 + TaxRate)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="round to two decimals"><em>RoundedPrice ← ROUND(TotalPrice, 2)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="display rounded total"><em>OUTPUT &quot;Total price is &quot;, RoundedPrice</em></span></div>
+          </div>
+        </div>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Generating a random number in a game range.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="generate random integer between 1 and 100"><em>SecretNumber ← RANDOM(1, 100)</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Library routines (ROUND, RANDOM)</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/1EHZ1B59T7s?start=140&end=189" title="IGCSE 8.1 Library routines - Cambridge pseudocode (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s9">
+    <h2>9. Apply relational operators: =, &lt;, &lt;=, &gt;, &gt;=, &lt;&gt; (not equal)</h2>
+    <ul class="bullets">
+      <li><strong>Relational operators</strong> compare values and return a <strong>Boolean</strong> result (TRUE or FALSE): = equal, &lt; less than, &gt; greater than, &lt;= less than or equal, &gt;= greater than or equal, &lt;&gt; not equal.
+        <ul>
+          <li>These comparisons are expressions that evaluate to TRUE or FALSE; later you will use them inside full statements.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Evaluated comparisons.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="comparison evaluates to TRUE"><em>10 &lt;= 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="comparison evaluates to FALSE"><em>11 &lt;= 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="comparison evaluates to FALSE"><em>10 &gt; 11</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="comparison evaluates to TRUE"><em>11 &gt; 10</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="comparison evaluates to TRUE"><em>10 &lt;&gt; 2</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Comparison operators</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/DR_hFLPysgM?start=201&end=289" title="IGCSE 8.1 Comparison operators only (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <div class="section" id="s10">
+    <h2>10. Use logical operators: AND, OR, NOT</h2>
+    <ul class="bullets">
+      <li>A <strong>Boolean operator</strong> combines or negates relational comparisons to produce a single TRUE or FALSE value: <strong>AND</strong> is TRUE only when both parts are TRUE; <strong>OR</strong> is TRUE when at least one part is TRUE; <strong>NOT</strong> reverses a Boolean value.
+        <ul>
+          <li>These are also expressions that produce TRUE or FALSE; you will later place them inside full statements.</li>
+        </ul>
+        <div class="example">
+           <div class="title"><strong>Example: </strong> Pure logical evaluations without control structures.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="TRUE because both parts are TRUE"><em>1 = 1 AND 2 = 2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="FALSE because the second part is FALSE"><em>1 = 1 AND 1 &gt; 2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="TRUE because at least one part is TRUE"><em>1 = 1 OR 1 &gt; 2</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="FALSE because NOT reverses the value"><em>NOT TRUE</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+  
+<div class="example video video-pink">  <div class="title">  Boolean operators (AND, OR, NOT)</div>
+  <div class="media">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/ddlHQ2J9O0s?start=14&end=226" title="IGCSE 8.1 Boolean operators only (trimmed)" loading="lazy" frameborder="0" allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+  </div>
+</div>
+</div>
+  <center> <a href="./Level%201/exercises.html" class="btn btn-cta" role="button">Ready to Practice</a></center>
+  <div class="footer">© IGCSE CS (0478) - Student notes prepared by Dr. Hamdeni</div>
+</div>
+
+<script>
+  function openPdfPopup() {
+    var url = './Level%201/basics.pdf'; // same folder
+    var w = Math.min(1000, Math.floor(window.screen.width * 0.85));
+    var h = Math.min(800,  Math.floor(window.screen.height * 0.85));
+    var left = Math.max(0, Math.floor((window.screen.width  - w) / 2));
+    var top  = Math.max(0, Math.floor((window.screen.height - h) / 2));
+    var features = [
+      'toolbar=no','location=no','status=no','menubar=no',
+      'scrollbars=yes','resizable=yes',
+      'width=' + w,'height=' + h,'left=' + left,'top=' + top
+    ].join(',');
+    var win = window.open(url, 'selectionPdf', features);
+    if (!win) return true;   // if popup is blocked, fall back to new tab
+    win.focus();
+    return false;            // prevent default navigation when popup succeeds
+  }
+</script>
+
+
+</body>
+</html>

--- a/igcse/levels/level3.html
+++ b/igcse/levels/level3.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Level 3: Selection</title>
+  <link rel="stylesheet" href="./levels.css">
+</head>
+<body>
+
+<!-- Header -->
+<div class="header">
+  <div class="container">
+    <!-- Top bar: logo + brand on the left, Home on the right -->
+    <div class="header-bar">
+      <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+        <img src="./logo.png" alt="logo" class="brand-logo">
+      </a>
+	  <div class="header-main">
+      <h1>Level 3: Selection</h1>
+      <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+    </div>
+     <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+  <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+    <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z"/>
+  </svg>
+  <span>Home</span>
+</a>
+
+    </div>
+
+    <!-- Centered title block -->
+    
+  </div>
+</div>
+
+<div class="container">
+
+  <div class="toc">
+    <strong>Contents</strong>
+    <ol>
+      <li><a href="#s1">Understand and use selection statements: IF-ELSE statements.</a></li>
+      <li><a href="#s2">Flowchart symbols for IF/ELSE</a></li>
+      <li><a href="#s3">CASE statements</a></li>
+	  <li><a href="./Level%202/selection.pdf"
+       onclick="return openPdfPopup();"
+       target="_blank" rel="noopener"
+       aria-label="Open the Selection PDF in a centered popup window">
+      Cambridge Pseudocode Syntax
+    </a></li>
+    </ol>
+  </div>
+  
+       <div class="section" id="s1">
+    <h2>0. Before you start</h2>
+
+
+  <table>
+  <tr>
+    <th><div class="example video video-pink">
+      <div class="title"> The 3 basic programming constructs... </div>
+      <div class="media">
+      <iframe  src="https://www.youtube.com/embed/eSYeHlwDCNA?si=u36FWk68dqmSrvFr" 
+	  title="YouTube video player" 
+	  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+	  allowfullscreen></iframe>
+	  
+	  
+      </div>
+    </div></th>
+    <th><div class="example video video-pink">
+      <div class="title"> ..."Selection" is one of them  </div>
+      <div class="media">
+       <iframe  src="https://www.youtube.com/embed/JDhQ36Rmc0M?si=tmoBqyPuQUAX_MHM" 
+	   title="YouTube video player"
+	    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+		allowfullscreen></iframe>
+      </div>
+    </div></th>
+  </tr>
+  </table
+   </div>
+
+	
+	
+	
+  <!-- Section 1: IF statements -->
+  <div class="section" id="s1">
+    <h2>1. Understand and use selection statements: IF statements.</h2>
+    <ul class="bullets">
+
+
+	
+	
+      <li>In an IF statement the THEN path runs when the condition is true, the ELSE path runs when it is false, and ENDIF marks the end; the ELSE part may be omitted.
+        <div class="example">
+		<div class="title"><strong>Example: </strong> IF with ELSE using one comparison</div>
+     
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="start IF and compare Age with 18"><em>IF Age &lt; 18</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="enter the THEN branch when the condition is true"><em>THEN</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="output the classification for a child"><em>OUTPUT "Child"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="switch to the ELSE branch when the condition is false"><em>ELSE</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="output the classification for an adult"><em>OUTPUT "Adult"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the IF structure"><em>ENDIF</em></span></div>
+          </div>
+          <p class="explain"><strong><strong>In simple terms:</strong></strong> The program asks a yes-or-no question about age. If the answer is yes (age is less than 18), it prints Child. If the answer is no, it prints Adult. The words IF, THEN, ELSE, and ENDIF mark the two possible paths and the end.</p>
+        </div>
+        <div class="example">
+		<div class="title"><strong>Example: </strong> ELSEIF and a final ELSE to output the larger number or report equality.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="first comparison: is Num1 greater than Num2?"><em>IF Num1 &gt; Num2 THEN</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="when Num1 is larger, display Num1"><em>OUTPUT (Num1)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="second comparison: test the opposite ordering"><em>ELSEIF Num2 &gt; Num1 THEN</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="when Num2 is larger, display Num2"><em>OUTPUT(Num2)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="fallback when neither comparison is true (values are equal)"><em>ELSE</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="state that the two values are identical"><em>OUTPUT ("They are the same")</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the IF / ELSEIF / ELSE structure"><em>ENDIF</em></span></div>
+          </div>
+          <p class="explain"><strong>In simple terms:</strong> The program compares two numbers. It first checks if Num1 is bigger; if yes, it prints Num1. If not, it checks if Num2 is bigger; if yes, it prints Num2. If neither is bigger, the last part runs and says the values are the same.</p>
+        </div>
+      </li>
+
+      <li>An IF condition can test a Boolean variable or a comparison, and comparisons can be combined using logical operators (lev. 1).
+        <ul>
+          <li>Comparison operators: &gt;, &lt;, =, &gt;=, &lt;=, &lt;&gt;;</li>
+		  <li>Logical operators: AND, OR, NOT.</li>
+        </ul>
+        <div class="example">
+		<div class="title"><strong>Example: </strong> IF using a Boolean variable</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="evaluate a Boolean variable called Found"><em>IF Found</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="enter THEN when Found is TRUE"><em>THEN</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="report a successful search"><em>OUTPUT "Your search was successful"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="enter ELSE when Found is FALSE"><em>ELSE</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="report an unsuccessful search"><em>OUTPUT "Your search was unsuccessful"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the IF structure"><em>ENDIF</em></span></div>
+          </div>
+          <p class="explain"><strong>In simple terms:</strong> The variable Found already holds TRUE or FALSE. If it is TRUE, the program prints that the search worked. Otherwise it prints that the search did not work. No extra comparison is needed because the variable itself is the condition.</p>
+        </div>
+        <div class="example">
+		<div class="title"><strong>Example: </strong> IF with a multi-part condition using OR, AND, and brackets.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="combined test on height, weight, and age (continuation on next line)"><em>IF ((Height &gt; 1) OR (Weight &gt; 20)) AND (Age &lt; 70) AND</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="complete the age range check"><em>(Age &gt; 5)</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="enter THEN when all required parts are TRUE"><em>THEN</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="allow access based on passing all conditions"><em>OUTPUT "You can ride"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="enter ELSE when any condition fails"><em>ELSE</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="deny access because at least one condition failed"><em>OUTPUT "Too small, too young or too old"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the IF structure"><em>ENDIF</em></span></div>
+          </div>
+          <p class="explain"><strong>In simple terms:</strong>  The program allows someone to ride if they are tall enough or heavy enough, and their age is between 6 and 69. The brackets keep the checks in the correct groups. If all the required parts are satisfied, it prints You can ride; otherwise it prints the warning message.</p>
+        </div>
+      </li>
+
+    
+    </ul>
+  
+    <div class="example video video-pink">
+      <div class="title">  IF statements</div>
+      <div class="media">
+        <iframe src="https://www.youtube.com/embed/QgffZbGnBvg?start=368&end=409"
+                title="CAMBRIDGE IGCSE (0478-0984) IF statements"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+      </div>
+    </div>
+</div>
+
+ <!-- Section 2: Flowchart symbols for IF/ELSE -->
+  <div class="section" id="s2">
+    <h2>2. Flowchart symbols for IF/ELSE</h2>
+    <ul class="bullets">
+      <li>In flowchart, we express the selection using "decision symbol" with YES/NO branches. The decision symbol looks like the following:
+          <p><img src="./Level%202/decision-symbol.png" width="150" alt=" decision symbol with YES/NO branches"></p>
+      </li>
+        <div class="example">
+        <div class="title"><strong>Example: </strong> Password validation flowchart</div>
+          <p><img src="./Level%202/password-flowchart.png" width="500" alt="Placeholder: password validation flowchart with two decisions"></p>
+        </div>
+      </li>
+    </ul>
+  
+    <div class="example video video-pink">
+      <div class="title">  Flowchart symbols for IF/ELSE </div>
+      <div class="media">
+        <iframe src="https://www.youtube.com/embed/kSpUGDYBnww?start=214&end=277"
+                title="CAMBRIDGE IGCSE (0478-0984) Flowchart symbols"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+      </div>
+    </div>
+</div>
+
+  <!-- Section 3: CASE statements -->
+  <div class="section" id="s3">
+    <h2>3. CASE statements</h2>
+    <ul class="bullets">
+	
+	<li>A CASE statement in pseudocode is a control structure used for multi-way branching, allowing different blocks of code to be executed based on the value of a single variable or expression.
+<ul>
+	<li>It provides a more structured and readable alternative to a series of nested IF-THEN-ELSE statements when dealing with multiple distinct conditions for the same variable.
+	</ul>
+	
+      <li>In a CASE statement the value of a single variable selects the matching path; OTHERWISE handles all other values, and ENDCASE marks the end.
+        <div class="example">
+		<div class="title"><strong>Example: </strong> CASE statement with several specific values and a default path.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="start dispatch based on the value of Grade"><em>CASE OF Grade</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="when Grade equals A, output Excellent"><em>'A' : OUTPUT "Excellent"</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="when Grade equals B, output Good"><em>'B' : OUTPUT "Good"</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="when Grade equals C, output Average"><em>'C' : OUTPUT "Average"</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="default action for all other grades"><em>OTHERWISE OUTPUT "Improvement is needed"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the CASE structure"><em>ENDCASE</em></span></div>
+          </div>
+          <p class="explain"><strong>In simple terms:</strong>  The program looks at the value in Grade and picks the matching line. If it is A, it prints Excellent; if it is B, it prints Good; if it is C, it prints Average. For any other value, the OTHERWISE line runs.</p>
+        </div>
+        <div class="example">
+				<div class="title"><strong>Example: </strong> CASE statement using numeric options with a default message.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="start dispatch based on the value of Choice"><em>CASE OF Choice</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="case 1: compute addition"><em>1 : Answer ← Num1 + Num2</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="case 2: compute subtraction"><em>2 : Answer ← Num1 - Num2</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="case 3: compute multiplication"><em>3 : Answer ← Num1 * Num2</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="case 4: compute division"><em>4 : Answer ← Num1 / Num2</em></span></div>
+            <div class="pc-line"><span class="indent">&nbsp;&nbsp;</span><span class="comment" data-tooltip="default action for any other option"><em>OTHERWISE OUTPUT "Please enter a valid choice"</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="terminate the CASE structure"><em>ENDCASE</em></span></div>
+          </div>
+          <p class="explain"><strong>In simple terms:</strong>  The number in Choice decides which calculation to make. Choices 1 to 4 do the four operations and store the result in Answer. If the number is not 1, 2, 3, or 4, the program prints a helpful message.</p>
+        </div>
+      </li>
+    </ul>
+  
+    <div class="example video video-pink">
+      <div class="title">  CASE statements</div>
+      <div class="media">
+        <iframe src="https://www.youtube.com/embed/QgffZbGnBvg?start=409&end=464"
+                title="CAMBRIDGE IGCSE (0478-0984) CASE statements"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen></iframe>
+      </div>
+    </div>
+</div>
+
+  <center> <a href="./Level%202/exercises.html" class="btn btn-cta" role="button">Ready to Practice</a> </center>
+
+  <div class="footer">© IGCSE CS (0478) - Student notes prepared by Dr. Hamdeni</div>
+
+
+</div>
+<script>
+  function openPdfPopup() {
+    var url = './Level%202/selection.pdf'; // same folder
+    var w = Math.min(1000, Math.floor(window.screen.width * 0.85));
+    var h = Math.min(800,  Math.floor(window.screen.height * 0.85));
+    var left = Math.max(0, Math.floor((window.screen.width  - w) / 2));
+    var top  = Math.max(0, Math.floor((window.screen.height - h) / 2));
+    var features = [
+      'toolbar=no','location=no','status=no','menubar=no',
+      'scrollbars=yes','resizable=yes',
+      'width=' + w,'height=' + h,'left=' + left,'top=' + top
+    ].join(',');
+    var win = window.open(url, 'selectionPdf', features);
+    if (!win) return true;   // if popup is blocked, fall back to new tab
+    win.focus();
+    return false;            // prevent default navigation when popup succeeds
+  }
+</script>
+
+</body>
+</html>

--- a/igcse/levels/level4.html
+++ b/igcse/levels/level4.html
@@ -1,0 +1,358 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Level 4: Count Controlled loop</title>
+  <link rel="stylesheet" href="./levels.css">
+</head>
+<body>
+
+<!-- Header -->
+<div class="header">
+  <div class="container">
+    <!-- Top bar: logo + brand on the left, Home on the right -->
+    <div class="header-bar">
+      <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+        <img src="./logo.png" alt="logo" class="brand-logo">
+      </a>
+	  <div class="header-main">
+      <h1>Level 4: Count Controlled loop</h1>
+      <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni</p>
+    </div>
+     <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+  <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+    <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z"/>
+  </svg>
+  <span>Home</span>
+</a>
+
+    </div>
+
+    <!-- Centered title block -->
+    
+  </div>
+</div>
+
+
+
+<div class="container">
+
+  <div class="toc">
+    <strong>Contents</strong>
+    <ol>
+      <li><a href="#s1">For loop</a></li>
+	  <li><a href="#s2">Flowchart</a></li> 
+	  <li><a href="#s3">The use of STEP</a></li>
+	  <li><a href="#s4">Nested For Loop</a></li>
+	  <li><a href="./Level%203/for.pdf"
+       onclick="return openPdfPopup();"
+       target="_blank" rel="noopener"
+       aria-label="Open the Selection PDF in a centered popup window">
+      Cambridge Pseudocode Syntax
+    </a></li>
+    </ol>
+  </div>
+
+
+
+       <div class="section" id="s1">
+    <h2>0. Before you start</h2>
+
+
+  <table>
+  <tr>
+    <th><div class="example video video-pink">
+      <div class="title"> The 3 basic programming constructs... </div>
+      <div class="media">
+     <iframe  src="https://www.youtube.com/embed/OoShU65HemA?si=ZHIwl8WK_2B4aLji" 
+	 title="YouTube video player" 
+	 allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+	 allowfullscreen></iframe>
+	  
+	  
+      </div>
+    </div></th>
+    <th><div class="example video video-pink">
+      <div class="title"> ..."Loop" is one of them  </div>
+      <div class="media">
+       
+	   <iframe  src="https://www.youtube.com/embed/sX02xbZ-1YA?si=BRHWNGupeD0snNbY" 
+	   title="YouTube video player" 
+	   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+	   allowfullscreen></iframe>
+	   
+      </div>
+    </div></th>
+  </tr>
+  </table>
+   </div>
+   
+   
+   
+   
+  <div class="section" id="s1">
+    <h2>1. FOR loop</h2>
+    <ul class="bullets">
+
+      <li data-tooltip="Definition and purpose: a count-controlled loop repeats a fixed number of times when the number of repetitions is known in advance. Structure: FOR … TO … NEXT with an integer counter. Inclusivity: the counter takes each integer from start to end inclusive; the loop finishes after executing the iteration in which the counter equals the end value. Step/direction: default step is +1; if the start value is greater than the end value (with default step), the loop executes zero times. Mutability: do not assign to the loop counter inside the body; the FOR structure changes it automatically.">
+        A count-controlled loop repeats a fixed number of times. It uses the structure FOR … TO … NEXT with a loop counter that changes each pass until the final value is reached.
+        <ul>
+          <li data-tooltip="Clarification of inclusivity and stop condition: the counter visits both bounds (inclusive). The test to stop occurs after the pass where the counter equals the end value.">
+            The counter takes each integer value from the start to the end inclusive; the loop ends after executing at the end value.
+          </li>
+          <li data-tooltip="Iteration counts and off-by-one awareness: 0..9 executes 10 iterations; 0..10 executes 11 iterations. Choose bounds deliberately to match the intended count.">
+            Common patterns include <code>FOR X ← 0 TO 9 … NEXT X</code> and <code>FOR Counter ← 0 TO 10 … NEXT Counter</code>.
+          </li>
+        </ul>
+
+        <div class="example">
+		        <div class="title"><strong>Example: </strong> FOR loop that executes a statement ten times.</div>
+          <div class="pseudocode">
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Count-controlled loop. Counter visits 1..10 inclusive → 10 iterations. Default step is +1. Do not alter Counter inside the loop. Use FOR when the repetition count is known beforehand.">
+                <em>FOR Counter ← 1 TO 10</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Body executes once per iteration (10 times). OUTPUT prints a literal string; parentheses are not required in this house style.">
+                <em> OUTPUT "*"</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="NEXT automatically increments the counter and prepares the next pass; termination happens after the end value has been processed.">
+                <em>NEXT Counter</em>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="example">
+				        <div class="title"><strong>Example: </strong>FOR loop that uses the counter in a calculation on each pass.</div>
+          <div class="pseudocode">
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Same 1..10 inclusive range → 10 iterations; counter value is available for calculations each pass.">
+                <em>FOR Counter ← 1 TO 10</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="The expression uses the current counter value. No parentheses are needed around OUTPUT arguments; operator precedence is clear.">
+                <em> OUTPUT Counter * Counter</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Control returns to FOR; Counter increases by 1.">
+                <em>NEXT Counter</em>
+              </span>
+            </div>
+          </div>
+        </div>
+
+      </li>
+
+      <li data-tooltip="When to choose FOR over WHILE/REPEAT: use FOR for a known, fixed number of repetitions. Prefer WHILE or REPEAT…UNTIL when the number of passes depends on a condition becoming true during execution (e.g., input validation).">
+        Use FOR … TO … NEXT when the number of repetitions is known in advance.
+      </li>
+
+    </ul>
+  </div>
+
+  <table>
+  <tr>
+    <th><div class="example video video-pink">
+      <div class="title">Count controlled loop example </div>
+      <div class="media">
+      <iframe
+	  src="https://www.youtube.com/embed/WXIaJsY5aU8?si=4OeAJjJu5QwWmb2y" 
+	  title="YouTube video player" 
+	  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+	  allowfullscreen></iframe>
+      </div>
+    </div>
+	</th>
+	
+    <th> <div class="example video video-pink">
+      <div class="title">More examples </div>
+      <div class="media">
+ 
+ <iframe  src="https://www.youtube.com/embed/TshzngmnCGA?si=wdXJhgQktKO2AUZP" 
+ title="YouTube video player" 
+ allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
+ allowfullscreen></iframe>
+      </div>
+    </div></th>
+  </tr>
+  </table>
+  
+  
+    
+	
+	
+
+
+
+  <div class="section" id="s2">
+    <h2>2. Flowchart</h2>
+
+    <ul class="bullets">
+      <li>Have a look at a flowchart showing how the checking for the alarm time sub-system
+works.
+          <p><img src="./Level%203/alarm.png" width="300" alt=" decision symbol with YES/NO branches"></p>
+      </li>
+        <div class="example">
+        <div class="title"><strong>Example: </strong> Concert ticket sales flowchart</div>
+		<p> Tickets are sold for a concert at $20 each, if 10 tickets are bought then the discount
+is 10%, if 20 tickets are bought the discount is 20%. No more than 25 tickets can be
+bought in a single transaction.
+This is flowchart showing an algorithm to calculate the cost of buying a given number
+of tickets:</p>
+          <p><img src="./Level%203/ticket.png" width="500"></p>
+        </div>
+      </li>
+    </ul>
+	
+  </div>
+
+<!-- 4. FOR with STEP (increment or decrement) -->
+  <div class="section" id="s3">
+  <h2>4. The use of STEP</h2>
+
+  <ul class="bullets">
+    <li data-tooltip="Use STEP to change the amount added to the loop counter each pass. The increment must be an integer. It can be negative for countdowns. The loop assigns successive counter values starting at the initial value and stops when the end would be passed.">
+      STEP changes the counter movement. The counter takes values from the start to the end using the given increment. If the next value would pass the end, the loop terminates.
+    </li>
+    <li data-tooltip="Termination rules: with a positive STEP the loop runs while the counter has not exceeded the end. With a negative STEP it runs while the counter has not gone below the end.">
+      Termination rules: positive STEP runs upward until the end is reached or passed; negative STEP runs downward until the end is reached or passed.
+    </li>
+    
+  </ul>
+
+  <div class="example">
+    <div class="title"><strong>Example: </strong>Odd numbers from 1 to 9 using STEP 2</div>
+    <div class="pseudocode">
+      <div class="pc-line"><span class="comment" data-tooltip="Start at 1, add 2 each time."><em>FOR i ← 1 TO 9 STEP 2</em></span></div>
+      <div class="pc-line"><span class="comment"><em>  OUTPUT i</em></span></div>
+      <div class="pc-line"><span class="comment"><em>NEXT i</em></span></div>
+    </div>
+    <p class="explain" data-tooltip="Sequence is 1, 3, 5, 7, 9 because 11 would pass the end.">Outputs: 1, 3, 5, 7, 9.</p>
+  </div>
+
+  <div class="example">
+    <div class="title"><strong>Example: </strong>Countdown in twos from 10 to 0</div>
+    <div class="pseudocode">
+      <div class="pc-line"><span class="comment" data-tooltip="Negative STEP counts down."><em>FOR n ← 10 TO 0 STEP -2</em></span></div>
+      <div class="pc-line"><span class="comment"><em>  OUTPUT n</em></span></div>
+      <div class="pc-line"><span class="comment"><em>NEXT n</em></span></div>
+    </div>
+    <p class="explain" data-tooltip="10, 8, 6, 4, 2, 0. Next value would be -2 which is below the end, so the loop stops.">Outputs: 10, 8, 6, 4, 2, 0.</p>
+  </div>
+
+  <div class="example">
+    <div class="title"><strong>Example: </strong>STEP that does not land exactly on the end</div>
+    <div class="pseudocode">
+      <div class="pc-line"><span class="comment" data-tooltip="1 → 5 → 9. The next value 13 would pass 10, so the loop terminates."><em>FOR j ← 1 TO 10 STEP 4</em></span></div>
+      <div class="pc-line"><span class="comment"><em>  OUTPUT j</em></span></div>
+      <div class="pc-line"><span class="comment"><em>NEXT j</em></span></div>
+    </div>
+    <p class="explain">Outputs: 1, 5, 9.</p>
+  </div>
+
+
+
+
+
+
+
+
+
+
+  <div class="section" id="s4">
+    <h2>4. Nested For Loop</h2>
+
+
+
+    
+    <ul class="bullets">
+      <li data-tooltip="Definition: nesting places one FOR loop inside another so the inner loop runs fully for each pass of the outer loop. Total iterations = (outer count) × (inner count). Each inner pass pairs with the current outer counter value.">
+        A nested FOR loop is one FOR … TO … NEXT inside another. The inner loop completes all of its iterations for every single iteration of the outer loop.
+
+        <div class="example">
+          <div class="title"><strong>Example: </strong>Generate a 3×4 multiplication grid (row × column).</div>
+          <div class="pseudocode">
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Outer loop: rows 1..3 (3 passes).">
+                <em>FOR Row ← 1 TO 3</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Inner loop: columns 1..4 (4 passes each time Row changes).">
+                <em>  FOR Col ← 1 TO 4</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Body runs 3 × 4 = 12 times; uses both counters.">
+                <em>    OUTPUT Row * Col</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Closes inner loop; Col is advanced automatically.">
+                <em>  NEXT Col</em>
+              </span>
+            </div>
+            <div class="pc-line">
+              <span class="comment" data-tooltip="Closes outer loop; Row is advanced automatically.">
+                <em>NEXT Row</em>
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div class="example">
+          <div class="title"><strong>Example: </strong>Display a 3×5 block of asterisks using a nested loop.</div>
+          <div class="pseudocode">
+            <div class="pc-line"><span class="comment" data-tooltip="Outer loop controls rows (3 rows)."><em>FOR Row ← 1 TO 3</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="Inner loop controls columns (5 stars per row)."><em>  FOR Col ← 1 TO 5</em></span></div>
+            <div class="pc-line"><span class="comment" data-tooltip="Outputs one asterisk per cell in the 3×5 grid."><em>    OUTPUT "*"</em></span></div>
+            <div class="pc-line"><span class="comment"><em>  NEXT Col</em></span></div>
+            <div class="pc-line"><span class="comment"><em>NEXT Row</em></span></div>
+          </div>
+        </div>
+      </li>
+    </ul>
+
+    <div class="example video video-pink">
+      <div class="title">Nested statements</div>
+      <div class="media">
+        <iframe
+          src="https://www.youtube.com/embed/eZqFsqVw4yw"
+          title="YouTube video player"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowfullscreen></iframe>
+      </div>
+    </div>
+
+
+<div class="footer">© IGCSE CS (0478) - Student notes prepared by Dr. Hamdeni</div>
+
+  <center> <a href="./Level%203/exercises.html" class="btn btn-cta" role="button">Ready to Practice</a> </center>
+
+<script>
+  function openPdfPopup() {
+    var url = './Level%203/for.pdf'; // same folder
+    var w = Math.min(1000, Math.floor(window.screen.width * 0.85));
+    var h = Math.min(800,  Math.floor(window.screen.height * 0.85));
+    var left = Math.max(0, Math.floor((window.screen.width  - w) / 2));
+    var top  = Math.max(0, Math.floor((window.screen.height - h) / 2));
+    var features = [
+      'toolbar=no','location=no','status=no','menubar=no',
+      'scrollbars=yes','resizable=yes',
+      'width=' + w,'height=' + h,'left=' + left,'top=' + top
+    ].join(',');
+    var win = window.open(url, 'selectionPdf', features);
+    if (!win) return true;   // if popup is blocked, fall back to new tab
+    win.focus();
+    return false;            // prevent default navigation when popup succeeds
+  }
+</script>
+</body>
+</html>

--- a/igcse/levels/level5.html
+++ b/igcse/levels/level5.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 5: Conditional Iteration</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 5: Conditional Iteration</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 5 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level6.html
+++ b/igcse/levels/level6.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 6: Standard Methods of Solution</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 6: Standard Methods of Solution</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 6 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level7.html
+++ b/igcse/levels/level7.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 7: String Handling & Nested Statements</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 7: String Handling & Nested Statements</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 7 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level8.html
+++ b/igcse/levels/level8.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 8: Arrays and Iterative Data Handling</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 8: Arrays and Iterative Data Handling</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 8 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/levels/level9.html
+++ b/igcse/levels/level9.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Level 9: Search and Sort</title>
+  <link rel="stylesheet" href="./levels.css" />
+</head>
+<body>
+  <div class="header">
+    <div class="container">
+      <div class="header-bar">
+        <a class="brand" href="../dashboard.html" aria-label="Go to dashboard">
+          <img src="./logo.png" alt="logo" class="brand-logo" />
+        </a>
+        <div class="header-main">
+          <h1>Level 9: Search and Sort</h1>
+          <p>IGCSE Computer Science (0478): student notes, prepared by Dr. Hamdeni.</p>
+        </div>
+        <a class="btn btn-home" href="../dashboard.html" aria-label="Go to dashboard">
+          <svg aria-hidden="true" viewBox="0 0 24 24" focusable="false">
+            <path d="M3 10.5L12 3l9 7.5v9a1 1 0 0 1-1 1h-5.5a1 1 0 0 1-1-1v-5h-3v5a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1v-9zM5 11.1V19h3.5v-5a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1v5H19v-7.9L12 5.6 5 11.1z" />
+          </svg>
+          <span>Home</span>
+        </a>
+      </div>
+    </div>
+  </div>
+  <main class="container">
+    <section class="section">
+      <h2>Learning materials on the way</h2>
+      <p>The detailed notes for Level 9 are being prepared. Please check back soon.</p>
+    </section>
+  </main>
+</body>
+</html>

--- a/igcse/modules/levelRenderer.js
+++ b/igcse/modules/levelRenderer.js
@@ -39,11 +39,8 @@ export async function renderProgrammingLevels() {
   levels.forEach((level, index) => {
     console.debug('[levelRenderer] Creating level box', level.id);
     const box = document.createElement("div");
-    const idNumber =
-      typeof level.id === 'string'
-        ? Number.parseInt(level.id.replace('level', ''), 10)
-        : Number.NaN;
-    const displayNumber = Number.isFinite(idNumber) ? idNumber : index;
+    const levelNumber = index + 1;
+    const displayNumber = levelNumber;
     let status = 'locked';
     if (index + 1 < reached) {
       status = 'passed';
@@ -51,7 +48,7 @@ export async function renderProgrammingLevels() {
       status = 'unlocked';
     }
     box.className = `level-box ${status}`;
-    box.dataset.level = String(displayNumber);
+    box.dataset.level = String(levelNumber);
 
     let icon = "";
     if (status === "locked") icon = "\uD83D\uDD12"; // 🔒
@@ -70,9 +67,8 @@ export async function renderProgrammingLevels() {
         if (box.classList.contains("locked")) {
           alert("This level is locked.");
         } else {
-          const levelFolder = `Level ${displayNumber}`;
-          const encodedFolder = encodeURIComponent(levelFolder);
-          window.location.href = `./levels/${encodedFolder}/notes.html`;
+          const targetPage = `level${levelNumber}.html`;
+          window.location.href = `./levels/${targetPage}`;
         }
       } catch (err) {
         console.error('[levelRenderer] Level box click error:', err);


### PR DESCRIPTION
## Summary
- update the dashboard level renderer to use sequential level numbers and link directly to levelN.html pages
- move the existing notes for levels 1-4 into new top-level HTML files with corrected asset paths
- add placeholder pages for levels 5-14 so every dashboard level opens a valid destination

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68daf41ef6a483318d80b645b45c8e42