### PR TITLE
Fix IGCSE level dashboard redirects

### DIFF
--- a/igcse/modules/levelRenderer.js
+++ b/igcse/modules/levelRenderer.js
@@ -70,9 +70,7 @@ export async function renderProgrammingLevels() {
         if (box.classList.contains("locked")) {
           alert("This level is locked.");
         } else {
-          const levelFolder = `Level ${displayNumber}`;
-          const encodedFolder = encodeURIComponent(levelFolder);
-          window.location.href = `./levels/${encodedFolder}/notes.html`;
+          window.location.href = `./levels/${level.id}.html`;
         }
       } catch (err) {
         console.error('[levelRenderer] Level box click error:', err);


### PR DESCRIPTION
## Summary
- update the IGCSE dashboard level click handler to route directly to the corresponding level HTML page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dafc4e31848331b60c1a05219d082b