### PR TITLE
Fix IGCSE progress level calculation and add regression test

### DIFF
--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,19 +1,32 @@
-import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+const SUPABASE_MODULE_URL = 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
 
 console.log('[supabaseClient] Loading Supabase client module');
+
+let createClient;
+if (typeof window !== 'undefined') {
+  ({ createClient } = await import(SUPABASE_MODULE_URL));
+} else {
+  createClient = () => ({
+    from() {
+      throw new Error('Supabase client is not available in this environment.');
+    }
+  });
+}
 
 export const SUPABASE_URL = "https://tsmzmuclrnyryuvanlxl.supabase.co";
 export const SUPABASE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InRzbXptdWNscm55cnl1dmFubHhsIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDc3MzM5NjUsImV4cCI6MjA2MzMwOTk2NX0.-l7Klmp5hKru3w2HOWLRPjCiQprJ2pOjsI-HPTGtAiw";
 
 console.log('[supabaseClient] Creating client with URL:', SUPABASE_URL);
-export const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
-  global: {
-    headers: {
-      apikey: SUPABASE_KEY,
-      Authorization: `Bearer ${SUPABASE_KEY}`
-    }
-  }
-});
+export const supabase = typeof window !== 'undefined'
+  ? createClient(SUPABASE_URL, SUPABASE_KEY, {
+      global: {
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`
+        }
+      }
+    })
+  : null;
 
 export function tableName(base) {
   const platform = localStorage.getItem('platform');
@@ -31,12 +44,14 @@ export function tableName(base) {
 }
 
 // expose helper for non-module scripts
-window.tableName = tableName;
+if (typeof window !== 'undefined') {
+  window.tableName = tableName;
 
-window.addEventListener('error', e => {
-  console.error('[Global Error]', e.message, e.error);
-});
+  window.addEventListener('error', e => {
+    console.error('[Global Error]', e.message, e.error);
+  });
 
-window.addEventListener('unhandledrejection', e => {
-  console.error('[Unhandled Promise Rejection]', e.reason);
-});
+  window.addEventListener('unhandledrejection', e => {
+    console.error('[Unhandled Promise Rejection]', e.reason);
+  });
+}

--- a/tests/igcse-progress.test.js
+++ b/tests/igcse-progress.test.js
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const storage = new Map();
+
+global.localStorage = {
+  getItem(key) {
+    return storage.has(key) ? storage.get(key) : null;
+  },
+  setItem(key, value) {
+    storage.set(key, value);
+  },
+  clear() {
+    storage.clear();
+  }
+};
+
+const { fetchProgressCounts } = await import('../igcse/modules/supabase.js');
+
+test('IGCSE student with level 1 completed is reported with 1 passed level', async () => {
+  storage.clear();
+  localStorage.setItem('username', 'alice');
+  localStorage.setItem('platform', 'IGCSE');
+
+  const responses = {
+    theory: {
+      ok: true,
+      async json() {
+        return [];
+      },
+      async text() {
+        return '';
+      }
+    },
+    level: {
+      ok: true,
+      async json() {
+        return [
+          { level_number: 1, level_done: true },
+          { level_number: 2, level_done: false }
+        ];
+      },
+      async text() {
+        return '';
+      }
+    }
+  };
+
+  global.fetch = async url => {
+    if (url.includes('theory')) return responses.theory;
+    if (url.includes('programming')) return responses.level;
+    throw new Error('Unexpected url: ' + url);
+  };
+
+  const result = await fetchProgressCounts();
+
+  assert.equal(result.levels, 1);
+  assert.equal(result.points, 0);
+  assert.ok(result.term1Grade >= 0);
+});


### PR DESCRIPTION
## Summary
- update the IGCSE progress fetcher to request level_number/level_done data, add error handling, and derive passed levels from completed rows
- guard the Supabase client module so it can be imported in the Node test environment
- add a regression test that exercises the IGCSE progress calculation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dbaa292edc8331947ee5671ab12707