### PR TITLE
Add compact submission-folder link to dashboard (login-gated)

### DIFF
--- a/a/dashboard.css
+++ b/a/dashboard.css
@@ -413,6 +413,38 @@ body {
   line-height: 1.1 !important;
 }
 
+.header-background + .header-row .submission-folder-link {
+  grid-column: 1 / 3 !important;
+  justify-self: start !important;
+  align-self: center !important;
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 6px !important;
+  padding: 6px 10px !important;
+  border-radius: 999px !important;
+  border: 1px solid rgba(76, 99, 210, 0.35) !important;
+  background: rgba(255, 255, 255, 0.9) !important;
+  color: #2f4bbc !important;
+  text-decoration: none !important;
+  font-size: 11px !important;
+  font-weight: 700 !important;
+  letter-spacing: 0.2px !important;
+  position: relative !important;
+  z-index: 1 !important;
+  transition: transform 0.2s ease, box-shadow 0.2s ease !important;
+}
+
+.header-background + .header-row .submission-folder-link:hover {
+  transform: translateY(-1px) !important;
+  box-shadow: 0 6px 14px rgba(76, 99, 210, 0.2) !important;
+}
+
+.header-background + .header-row .submission-folder-link.disabled {
+  opacity: 0.5 !important;
+  pointer-events: none !important;
+  box-shadow: none !important;
+}
+
 @media (max-width: 820px) {
   .header-background + .header-row .general-progress-wrapper {
     grid-template-columns: 1fr !important;
@@ -420,6 +452,7 @@ body {
 
   .header-background + .header-row .general-progress-label,
   .header-background + .header-row .general-progress-bar,
+  .header-background + .header-row .submission-folder-link,
   .header-background + .header-row .term-grade-badge {
     grid-column: 1 / -1 !important;
   }

--- a/a/dashboard.html
+++ b/a/dashboard.html
@@ -38,6 +38,9 @@
           <div class="general-progress-fill">0%</div>
           <div class="general-progress-max">100%</div>
         </div>
+        <a id="submission-folder-link" class="submission-folder-link disabled" href="#" aria-disabled="true" tabindex="-1">
+          📁 Submission folder
+        </a>
         <a class="term-grade-badge" href="https://turkiyemaarif-my.sharepoint.com/:x:/g/personal/chams-eddine_hemdani_tn_maarifschools_org/IQB4RhXt09uRSoBWwzyl0QQCAXfb5sEjLYTaWdpJTggSZ-s?e=MbHOq9" aria-describedby="term-grade-tooltip" target="_blank" rel="noopener noreferrer">
           <span class="term-grade-label">TERM 2 GRADE</span>
           <span id="term-grade-value" class="term-grade-value">0%</span>

--- a/a/dashboard.js
+++ b/a/dashboard.js
@@ -1,7 +1,7 @@
 
 import { renderTheoryPoints } from "./modules/theoryRenderer.js";
 import { renderProgrammingLevels } from "./modules/levelRenderer.js";
-import { initializeLogin, fetchProgressCounts, verifyPlatform } from "./modules/supabase.js";
+import { initializeLogin, fetchProgressCounts, fetchStudentSubmissionLink, verifyPlatform } from "./modules/supabase.js";
 
 async function updateGeneralProgress() {
   const fill = document.querySelector(".general-progress-fill");
@@ -58,6 +58,37 @@ async function updateGeneralProgress() {
   console.debug('[dashboard] Progress percent', roundedPercent);
 }
 
+async function updateSubmissionFolderLink() {
+  const linkEl = document.getElementById("submission-folder-link");
+  if (!linkEl) return;
+
+  const username = localStorage.getItem("username");
+
+  if (!username) {
+    linkEl.classList.add("disabled");
+    linkEl.setAttribute("aria-disabled", "true");
+    linkEl.setAttribute("tabindex", "-1");
+    linkEl.removeAttribute("href");
+    return;
+  }
+
+  const submissionLink = await fetchStudentSubmissionLink();
+  if (!submissionLink) {
+    linkEl.classList.add("disabled");
+    linkEl.setAttribute("aria-disabled", "true");
+    linkEl.setAttribute("tabindex", "-1");
+    linkEl.removeAttribute("href");
+    return;
+  }
+
+  linkEl.classList.remove("disabled");
+  linkEl.setAttribute("href", submissionLink);
+  linkEl.setAttribute("target", "_blank");
+  linkEl.setAttribute("rel", "noopener noreferrer");
+  linkEl.setAttribute("aria-disabled", "false");
+  linkEl.removeAttribute("tabindex");
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   console.log("✅ DOM fully loaded, running dashboard.js");
 
@@ -67,6 +98,7 @@ document.addEventListener("DOMContentLoaded", () => {
   renderProgrammingLevels();
   initializeLogin();
   updateGeneralProgress();
+  updateSubmissionFolderLink();
 
   const homeBtn = document.getElementById("home-btn");
   if (homeBtn) {

--- a/a/modules/supabase.js
+++ b/a/modules/supabase.js
@@ -110,6 +110,51 @@ export async function fetchProgressCounts() {
   }
 }
 
+export async function fetchStudentSubmissionLink() {
+  const username = localStorage.getItem('username');
+  const studentId = localStorage.getItem('student_id');
+  const uuid = localStorage.getItem('uuid');
+
+  const identifiers = [
+    ['id', studentId],
+    ['username', username],
+    ['uuid', uuid]
+  ].filter(([, value]) => Boolean(value));
+
+  if (!identifiers.length) {
+    return '';
+  }
+
+  const base = `${SUPABASE_URL}/rest/v1`;
+
+  for (const [column, value] of identifiers) {
+    const encodedValue = encodeURIComponent(value);
+    try {
+      const response = await fetch(`${base}/students?select=Link&${column}=eq.${encodedValue}`, {
+        method: 'GET',
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: 'Bearer ' + SUPABASE_KEY
+        }
+      });
+
+      if (!response.ok) {
+        continue;
+      }
+
+      const data = await response.json();
+      const link = Array.isArray(data) && data.length ? data[0]?.Link : '';
+      if (link) {
+        return link;
+      }
+    } catch (err) {
+      console.warn(`[supabaseModule] Failed to fetch Link by ${column}:`, err);
+    }
+  }
+
+  return '';
+}
+
 export function initializeLogin() {
   console.log('[supabaseModule] Initializing login handlers');
   verifyPlatform();


### PR DESCRIPTION
### Motivation
- Provide students a quick, per-user link to their submission folder from the A-Level dashboard header while keeping the UI compact. 
- Ensure the control is disabled for guests and only becomes clickable when a valid user-specific folder URL exists. 

### Description
- Added a small pill-style anchor inside the progress box in `a/dashboard.html` (`#submission-folder-link`) and made it disabled by default for guests. 
- Implemented `updateSubmissionFolderLink()` in `a/dashboard.js` to gate the link by login state, attach accessible attributes (`aria-disabled`, `tabindex`), and open the folder in a new tab when available. 
- Added `fetchStudentSubmissionLink()` to `a/modules/supabase.js` which looks up the `students.Link` field via the Supabase REST API using `student_id`, `username`, or `uuid` from `localStorage`. 
- Added compact responsive styles in `a/dashboard.css` for the new pill link and a clear disabled state so the addition stays visually small and stacks correctly on narrow screens. 

### Testing
- Performed static syntax checks with `node --check a/dashboard.js` which succeeded. 
- Performed static syntax checks with `node --check a/modules/supabase.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3294c9a88331a141841263bc6566)